### PR TITLE
Update readme.org with babel pointer

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -10,9 +10,7 @@
 
 ** Introduction
 
-[[https://www.gnu.org/software/emacs/][Emacs]] is an extensible text editor.  [[https://orgmode.org/][Org]] is an emacs mode for structured text.
-
-[[#layer-tables][Layers]] are maintained in org tables.  The tables are [[#tangling][tangled]] into Miryoku implementation [[#tangled-files][source files]] via [[#scripts-and-data][python scripts and additional data tables]].
+[[https://www.gnu.org/software/emacs/][Emacs]] is an extensible text editor.  [[https://orgmode.org/][Org]] is an emacs mode for structured text. [[https://orgmode.org/worg/org-contrib/babel/][Babel]] is Emacs' Org mode's ability to execute source code from within Org mode documents. This document contains [[#layer-tables][layers]], which are maintained in org tables.  The tables are [[#tangling][tangled]] into Miryoku implementation [[#tangled-files][source files]] via [[#scripts-and-data][python scripts and additional data tables]].
 
 Changes to Miryoku layers can be made with convenient [[https://orgmode.org/manual/Built_002din-Table-Editor.html][org table editing commands]].
 


### PR DESCRIPTION
For non emacs users, it's unclear what the relationship between emacs, org mode, and babel is. Adding a few clarifying sentences.