### PR TITLE
Draft: First step towards making a "wide" (3x12) Miryoku for crkbd

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -261,6 +261,16 @@ The base layer is maintained as separate tables for tap alphas, tap thumbs, and 
 | Z    | X    | C    | V    | B    | N    | M    | ,    | DOT  | /    |
 
 
+***** QWERTY_NORMAL
+
+~MIRYOKU_ALPHAS=QWERTY_NORMAL~
+
+#+NAME: qwerty_normal
+| Q    | W    | E    | R    | T    | Y    | U    | I    | O    | P    |
+| A    | S    | D    | F    | G    | H    | J    | K    | L    | SCLN |
+| Z    | X    | C    | V    | B    | N    | M    | ,    | DOT  | /    |
+
+
 ***** QWERTZ
 
 ~MIRYOKU_ALPHAS=QWERTZ~
@@ -269,6 +279,23 @@ The base layer is maintained as separate tables for tap alphas, tap thumbs, and 
 | Q    | W    | E    | R    | T    | Z    | U    | I    | O    | P    |
 | A    | S    | D    | F    | G    | H    | J    | K    | L    | '    |
 | Y    | X    | C    | V    | B    | N    | M    | ,    | DOT  | /    |
+
+
+**** Padding
+
+***** 3x12 (crkbd)
+
+~MIRYOKU_PADDING=3x12~
+
+#+NAME: 3x12
+| TAB  | BSPC |
+| LCTL | QUOT |
+| LSFT | ESC  |
+
+# qmk_firmware/keyboards/crkbd/keymaps/default/keymap.c contains:
+# KC_TAB,  KC_Q, KC_W, KC_E, KC_R, KC_T,   KC_Y, KC_U, KC_I,    KC_O,   KC_P,    KC_BSPC,
+# KC_LCTL, KC_A, KC_S, KC_D, KC_F, KC_G,   KC_H, KC_J, KC_K,    KC_L,   KC_SCLN, KC_QUOT,
+# KC_LSFT, KC_Z, KC_X, KC_C, KC_V, KC_B,   KC_N, KC_M, KC_COMM, KC_DOT, KC_SLSH, KC_ESC,
 
 
 **** Nav
@@ -1257,6 +1284,9 @@ prepended.
 #define MIRYOKU_ALTERNATIVES_BASE_QWERTY_FLIP \
 <<table-layer-taphold(alphas_table=qwerty, thumbs_table=thumbs-flip, hold_table=hold-flip)>>
 
+#define MIRYOKU_ALTERNATIVES_BASE_QWERTY_NORMAL_FLIP \
+<<table-layer-taphold(alphas_table=qwerty_normal, thumbs_table=thumbs-flip, hold_table=hold-flip)>>
+
 #define MIRYOKU_ALTERNATIVES_BASE_QWERTZ_FLIP \
 <<table-layer-taphold(alphas_table=qwertz, thumbs_table=thumbs-flip, hold_table=hold-flip)>>
 
@@ -1286,6 +1316,9 @@ prepended.
 
 #define MIRYOKU_ALTERNATIVES_BASE_QWERTY \
 <<table-layer-taphold(alphas_table=qwerty)>>
+
+#define MIRYOKU_ALTERNATIVES_BASE_QWERTY_NORMAL \
+<<table-layer-taphold(alphas_table=qwerty_normal)>>
 
 #define MIRYOKU_ALTERNATIVES_BASE_QWERTZ \
 <<table-layer-taphold(alphas_table=qwertz)>>
@@ -1318,6 +1351,9 @@ prepended.
 #define MIRYOKU_ALTERNATIVES_TAP_QWERTY_FLIP \
 <<table-layer-full(alphas_table=qwerty, thumbs_table=thumbs-flip)>>
 
+#define MIRYOKU_ALTERNATIVES_TAP_QWERTY_NORMAL_FLIP \
+<<table-layer-full(alphas_table=qwerty_normal, thumbs_table=thumbs-flip)>>
+
 #define MIRYOKU_ALTERNATIVES_TAP_QWERTZ_FLIP \
 <<table-layer-full(alphas_table=qwertz, thumbs_table=thumbs-flip)>>
 
@@ -1347,6 +1383,9 @@ prepended.
 
 #define MIRYOKU_ALTERNATIVES_TAP_QWERTY \
 <<table-layer-full(alphas_table=qwerty, thumbs_table=thumbs)>>
+
+#define MIRYOKU_ALTERNATIVES_TAP_QWERTY_NORMAL \
+<<table-layer-full(alphas_table=qwerty_normal, thumbs_table=thumbs)>>
 
 #define MIRYOKU_ALTERNATIVES_TAP_QWERTZ \
 <<table-layer-full(alphas_table=qwertz, thumbs_table=thumbs)>>
@@ -1500,6 +1539,9 @@ prepended.
 #define MIRYOKU_ALTERNATIVES_BASE_QWERTY_FLIP \
 <<table-layer-taphold(alphas_table=qwerty, thumbs_table=thumbs-flip, hold_table=hold-flip)>>
 
+#define MIRYOKU_ALTERNATIVES_BASE_QWERTY_NORMAL_FLIP \
+<<table-layer-taphold(alphas_table=qwerty_normal, thumbs_table=thumbs-flip, hold_table=hold-flip)>>
+
 #define MIRYOKU_ALTERNATIVES_BASE_QWERTZ_FLIP \
 <<table-layer-taphold(alphas_table=qwertz, thumbs_table=thumbs-flip, hold_table=hold-flip)>>
 
@@ -1529,6 +1571,9 @@ prepended.
 
 #define MIRYOKU_ALTERNATIVES_BASE_QWERTY \
 <<table-layer-taphold(alphas_table=qwerty)>>
+
+#define MIRYOKU_ALTERNATIVES_BASE_QWERTY_NORMAL \
+<<table-layer-taphold(alphas_table=qwerty_normal)>>
 
 #define MIRYOKU_ALTERNATIVES_BASE_QWERTZ \
 <<table-layer-taphold(alphas_table=qwertz)>>
@@ -1561,6 +1606,9 @@ prepended.
 #define MIRYOKU_ALTERNATIVES_TAP_QWERTY_FLIP \
 <<table-layer-full(alphas_table=qwerty, thumbs_table=thumbs-flip)>>
 
+#define MIRYOKU_ALTERNATIVES_TAP_QWERTY_NORMAL_FLIP \
+<<table-layer-full(alphas_table=qwerty_normal, thumbs_table=thumbs-flip)>>
+
 #define MIRYOKU_ALTERNATIVES_TAP_QWERTZ_FLIP \
 <<table-layer-full(alphas_table=qwertz, thumbs_table=thumbs-flip)>>
 
@@ -1590,6 +1638,9 @@ prepended.
 
 #define MIRYOKU_ALTERNATIVES_TAP_QWERTY \
 <<table-layer-full(alphas_table=qwerty, thumbs_table=thumbs)>>
+
+#define MIRYOKU_ALTERNATIVES_TAP_QWERTY_NORMAL \
+<<table-layer-full(alphas_table=qwerty_normal, thumbs_table=thumbs)>>
 
 #define MIRYOKU_ALTERNATIVES_TAP_QWERTZ \
 <<table-layer-full(alphas_table=qwertz, thumbs_table=thumbs)>>
@@ -1741,6 +1792,9 @@ prepended.
 #define MIRYOKU_ALTERNATIVES_BASE_QWERTY_FLIP \
 <<table-layer-taphold(alphas_table=qwerty, thumbs_table=thumbs-flip, hold_table=hold-flip)>>
 
+#define MIRYOKU_ALTERNATIVES_BASE_QWERTY_NORMAL_FLIP \
+<<table-layer-taphold(alphas_table=qwerty_normal, thumbs_table=thumbs-flip, hold_table=hold-flip)>>
+
 #define MIRYOKU_ALTERNATIVES_BASE_QWERTZ_FLIP \
 <<table-layer-taphold(alphas_table=qwertz, thumbs_table=thumbs-flip, hold_table=hold-flip)>>
 
@@ -1770,6 +1824,9 @@ prepended.
 
 #define MIRYOKU_ALTERNATIVES_BASE_QWERTY \
 <<table-layer-taphold(alphas_table=qwerty)>>
+
+#define MIRYOKU_ALTERNATIVES_BASE_QWERTY_NORMAL \
+<<table-layer-taphold(alphas_table=qwerty_normal)>>
 
 #define MIRYOKU_ALTERNATIVES_BASE_QWERTZ \
 <<table-layer-taphold(alphas_table=qwertz)>>
@@ -1802,6 +1859,9 @@ prepended.
 #define MIRYOKU_ALTERNATIVES_TAP_QWERTY_FLIP \
 <<table-layer-full(alphas_table=qwerty, thumbs_table=thumbs-flip)>>
 
+#define MIRYOKU_ALTERNATIVES_TAP_QWERTY_NORMAL_FLIP \
+<<table-layer-full(alphas_table=qwerty_normal, thumbs_table=thumbs-flip)>>
+
 #define MIRYOKU_ALTERNATIVES_TAP_QWERTZ_FLIP \
 <<table-layer-full(alphas_table=qwertz, thumbs_table=thumbs-flip)>>
 
@@ -1831,6 +1891,9 @@ prepended.
 
 #define MIRYOKU_ALTERNATIVES_TAP_QWERTY \
 <<table-layer-full(alphas_table=qwerty, thumbs_table=thumbs)>>
+
+#define MIRYOKU_ALTERNATIVES_TAP_QWERTY_NORMAL \
+<<table-layer-full(alphas_table=qwerty_normal, thumbs_table=thumbs)>>
 
 #define MIRYOKU_ALTERNATIVES_TAP_QWERTZ \
 <<table-layer-full(alphas_table=qwertz, thumbs_table=thumbs)>>

--- a/tangled/kmonad/miryoku_layer_alternatives.h
+++ b/tangled/kmonad/miryoku_layer_alternatives.h
@@ -60,6 +60,12 @@ U_MT(a, met),      U_MT(s, alt),      U_MT(d, ctl),      U_MT(f, sft),      g,  
 U_LT(z, U_BUTTON), U_MT(x, ralt),     c,                 v,                 b,                 n,                 m,                 U_COMM,            U_MT(., ralt),     U_LT(/, U_BUTTON), \
 U_NP,              U_NP,              U_LT(del, U_FUN),  U_LT(bspc, U_NUM), U_LT(ent, U_SYM),  U_LT(tab, U_MOUSE),U_LT(spc, U_NAV),  U_LT(esc, U_MEDIA),U_NP,              U_NP
 
+#define MIRYOKU_ALTERNATIVES_BASE_QWERTY_NORMAL_FLIP \
+q,                 w,                 e,                 r,                 t,                 y,                 u,                 i,                 o,                 p,                 \
+U_MT(a, met),      U_MT(s, alt),      U_MT(d, ctl),      U_MT(f, sft),      g,                 h,                 U_MT(j, sft),      U_MT(k, ctl),      U_MT(l, alt),      U_MT(;, met),      \
+U_LT(z, U_BUTTON), U_MT(x, ralt),     c,                 v,                 b,                 n,                 m,                 U_COMM,            U_MT(., ralt),     U_LT(/, U_BUTTON), \
+U_NP,              U_NP,              U_LT(del, U_FUN),  U_LT(bspc, U_NUM), U_LT(ent, U_SYM),  U_LT(tab, U_MOUSE),U_LT(spc, U_NAV),  U_LT(esc, U_MEDIA),U_NP,              U_NP
+
 #define MIRYOKU_ALTERNATIVES_BASE_QWERTZ_FLIP \
 q,                 w,                 e,                 r,                 t,                 z,                 u,                 i,                 o,                 p,                 \
 U_MT(a, met),      U_MT(s, alt),      U_MT(d, ctl),      U_MT(f, sft),      g,                 h,                 U_MT(j, sft),      U_MT(k, ctl),      U_MT(l, alt),      U_MT(U_QUOT, met), \
@@ -117,6 +123,12 @@ U_NP,              U_NP,              U_LT(esc, U_MEDIA),U_LT(spc, U_NAV),  U_LT
 #define MIRYOKU_ALTERNATIVES_BASE_QWERTY \
 q,                 w,                 e,                 r,                 t,                 y,                 u,                 i,                 o,                 p,                 \
 U_MT(a, met),      U_MT(s, alt),      U_MT(d, ctl),      U_MT(f, sft),      g,                 h,                 U_MT(j, sft),      U_MT(k, ctl),      U_MT(l, alt),      U_MT(U_QUOT, met), \
+U_LT(z, U_BUTTON), U_MT(x, ralt),     c,                 v,                 b,                 n,                 m,                 U_COMM,            U_MT(., ralt),     U_LT(/, U_BUTTON), \
+U_NP,              U_NP,              U_LT(esc, U_MEDIA),U_LT(spc, U_NAV),  U_LT(tab, U_MOUSE),U_LT(ent, U_SYM),  U_LT(bspc, U_NUM), U_LT(del, U_FUN),  U_NP,              U_NP
+
+#define MIRYOKU_ALTERNATIVES_BASE_QWERTY_NORMAL \
+q,                 w,                 e,                 r,                 t,                 y,                 u,                 i,                 o,                 p,                 \
+U_MT(a, met),      U_MT(s, alt),      U_MT(d, ctl),      U_MT(f, sft),      g,                 h,                 U_MT(j, sft),      U_MT(k, ctl),      U_MT(l, alt),      U_MT(;, met),      \
 U_LT(z, U_BUTTON), U_MT(x, ralt),     c,                 v,                 b,                 n,                 m,                 U_COMM,            U_MT(., ralt),     U_LT(/, U_BUTTON), \
 U_NP,              U_NP,              U_LT(esc, U_MEDIA),U_LT(spc, U_NAV),  U_LT(tab, U_MOUSE),U_LT(ent, U_SYM),  U_LT(bspc, U_NUM), U_LT(del, U_FUN),  U_NP,              U_NP
 
@@ -181,6 +193,12 @@ a,                 s,                 d,                 f,                 g,  
 z,                 x,                 c,                 v,                 b,                 n,                 m,                 U_COMM,            .,                 /,                 \
 U_NP,              U_NP,              del,               bspc,              ent,               tab,               spc,               esc,               U_NP,              U_NP
 
+#define MIRYOKU_ALTERNATIVES_TAP_QWERTY_NORMAL_FLIP \
+q,                 w,                 e,                 r,                 t,                 y,                 u,                 i,                 o,                 p,                 \
+a,                 s,                 d,                 f,                 g,                 h,                 j,                 k,                 l,                 ;,                 \
+z,                 x,                 c,                 v,                 b,                 n,                 m,                 U_COMM,            .,                 /,                 \
+U_NP,              U_NP,              del,               bspc,              ent,               tab,               spc,               esc,               U_NP,              U_NP
+
 #define MIRYOKU_ALTERNATIVES_TAP_QWERTZ_FLIP \
 q,                 w,                 e,                 r,                 t,                 z,                 u,                 i,                 o,                 p,                 \
 a,                 s,                 d,                 f,                 g,                 h,                 j,                 k,                 l,                 U_QUOT,            \
@@ -238,6 +256,12 @@ U_NP,              U_NP,              esc,               spc,               tab,
 #define MIRYOKU_ALTERNATIVES_TAP_QWERTY \
 q,                 w,                 e,                 r,                 t,                 y,                 u,                 i,                 o,                 p,                 \
 a,                 s,                 d,                 f,                 g,                 h,                 j,                 k,                 l,                 U_QUOT,            \
+z,                 x,                 c,                 v,                 b,                 n,                 m,                 U_COMM,            .,                 /,                 \
+U_NP,              U_NP,              esc,               spc,               tab,               ent,               bspc,              del,               U_NP,              U_NP
+
+#define MIRYOKU_ALTERNATIVES_TAP_QWERTY_NORMAL \
+q,                 w,                 e,                 r,                 t,                 y,                 u,                 i,                 o,                 p,                 \
+a,                 s,                 d,                 f,                 g,                 h,                 j,                 k,                 l,                 ;,                 \
 z,                 x,                 c,                 v,                 b,                 n,                 m,                 U_COMM,            .,                 /,                 \
 U_NP,              U_NP,              esc,               spc,               tab,               ent,               bspc,              del,               U_NP,              U_NP
 

--- a/tangled/qmk/miryoku_layer_alternatives.h
+++ b/tangled/qmk/miryoku_layer_alternatives.h
@@ -62,6 +62,12 @@ LGUI_T(KC_A),      LALT_T(KC_S),      LCTL_T(KC_D),      LSFT_T(KC_F),      KC_G
 LT(U_BUTTON,KC_Z), ALGR_T(KC_X),      KC_C,              KC_V,              KC_B,              KC_N,              KC_M,              KC_COMM,           ALGR_T(KC_DOT),    LT(U_BUTTON,KC_SLSH),\
 U_NP,              U_NP,              LT(U_FUN,KC_DEL),  LT(U_NUM,KC_BSPC), LT(U_SYM,KC_ENT),  LT(U_MOUSE,KC_TAB),LT(U_NAV,KC_SPC),  LT(U_MEDIA,KC_ESC),U_NP,              U_NP
 
+#define MIRYOKU_ALTERNATIVES_BASE_QWERTY_NORMAL_FLIP \
+KC_Q,              KC_W,              KC_E,              KC_R,              KC_T,              KC_Y,              KC_U,              KC_I,              KC_O,              KC_P,              \
+LGUI_T(KC_A),      LALT_T(KC_S),      LCTL_T(KC_D),      LSFT_T(KC_F),      KC_G,              KC_H,              LSFT_T(KC_J),      LCTL_T(KC_K),      LALT_T(KC_L),      LGUI_T(KC_SCLN),   \
+LT(U_BUTTON,KC_Z), ALGR_T(KC_X),      KC_C,              KC_V,              KC_B,              KC_N,              KC_M,              KC_COMM,           ALGR_T(KC_DOT),    LT(U_BUTTON,KC_SLSH),\
+U_NP,              U_NP,              LT(U_FUN,KC_DEL),  LT(U_NUM,KC_BSPC), LT(U_SYM,KC_ENT),  LT(U_MOUSE,KC_TAB),LT(U_NAV,KC_SPC),  LT(U_MEDIA,KC_ESC),U_NP,              U_NP
+
 #define MIRYOKU_ALTERNATIVES_BASE_QWERTZ_FLIP \
 KC_Q,              KC_W,              KC_E,              KC_R,              KC_T,              KC_Z,              KC_U,              KC_I,              KC_O,              KC_P,              \
 LGUI_T(KC_A),      LALT_T(KC_S),      LCTL_T(KC_D),      LSFT_T(KC_F),      KC_G,              KC_H,              LSFT_T(KC_J),      LCTL_T(KC_K),      LALT_T(KC_L),      LGUI_T(KC_QUOT),   \
@@ -119,6 +125,12 @@ U_NP,              U_NP,              LT(U_MEDIA,KC_ESC),LT(U_NAV,KC_SPC),  LT(U
 #define MIRYOKU_ALTERNATIVES_BASE_QWERTY \
 KC_Q,              KC_W,              KC_E,              KC_R,              KC_T,              KC_Y,              KC_U,              KC_I,              KC_O,              KC_P,              \
 LGUI_T(KC_A),      LALT_T(KC_S),      LCTL_T(KC_D),      LSFT_T(KC_F),      KC_G,              KC_H,              LSFT_T(KC_J),      LCTL_T(KC_K),      LALT_T(KC_L),      LGUI_T(KC_QUOT),   \
+LT(U_BUTTON,KC_Z), ALGR_T(KC_X),      KC_C,              KC_V,              KC_B,              KC_N,              KC_M,              KC_COMM,           ALGR_T(KC_DOT),    LT(U_BUTTON,KC_SLSH),\
+U_NP,              U_NP,              LT(U_MEDIA,KC_ESC),LT(U_NAV,KC_SPC),  LT(U_MOUSE,KC_TAB),LT(U_SYM,KC_ENT),  LT(U_NUM,KC_BSPC), LT(U_FUN,KC_DEL),  U_NP,              U_NP
+
+#define MIRYOKU_ALTERNATIVES_BASE_QWERTY_NORMAL \
+KC_Q,              KC_W,              KC_E,              KC_R,              KC_T,              KC_Y,              KC_U,              KC_I,              KC_O,              KC_P,              \
+LGUI_T(KC_A),      LALT_T(KC_S),      LCTL_T(KC_D),      LSFT_T(KC_F),      KC_G,              KC_H,              LSFT_T(KC_J),      LCTL_T(KC_K),      LALT_T(KC_L),      LGUI_T(KC_SCLN),   \
 LT(U_BUTTON,KC_Z), ALGR_T(KC_X),      KC_C,              KC_V,              KC_B,              KC_N,              KC_M,              KC_COMM,           ALGR_T(KC_DOT),    LT(U_BUTTON,KC_SLSH),\
 U_NP,              U_NP,              LT(U_MEDIA,KC_ESC),LT(U_NAV,KC_SPC),  LT(U_MOUSE,KC_TAB),LT(U_SYM,KC_ENT),  LT(U_NUM,KC_BSPC), LT(U_FUN,KC_DEL),  U_NP,              U_NP
 
@@ -183,6 +195,12 @@ KC_A,              KC_S,              KC_D,              KC_F,              KC_G
 KC_Z,              KC_X,              KC_C,              KC_V,              KC_B,              KC_N,              KC_M,              KC_COMM,           KC_DOT,            KC_SLSH,           \
 U_NP,              U_NP,              KC_DEL,            KC_BSPC,           KC_ENT,            KC_TAB,            KC_SPC,            KC_ESC,            U_NP,              U_NP
 
+#define MIRYOKU_ALTERNATIVES_TAP_QWERTY_NORMAL_FLIP \
+KC_Q,              KC_W,              KC_E,              KC_R,              KC_T,              KC_Y,              KC_U,              KC_I,              KC_O,              KC_P,              \
+KC_A,              KC_S,              KC_D,              KC_F,              KC_G,              KC_H,              KC_J,              KC_K,              KC_L,              KC_SCLN,           \
+KC_Z,              KC_X,              KC_C,              KC_V,              KC_B,              KC_N,              KC_M,              KC_COMM,           KC_DOT,            KC_SLSH,           \
+U_NP,              U_NP,              KC_DEL,            KC_BSPC,           KC_ENT,            KC_TAB,            KC_SPC,            KC_ESC,            U_NP,              U_NP
+
 #define MIRYOKU_ALTERNATIVES_TAP_QWERTZ_FLIP \
 KC_Q,              KC_W,              KC_E,              KC_R,              KC_T,              KC_Z,              KC_U,              KC_I,              KC_O,              KC_P,              \
 KC_A,              KC_S,              KC_D,              KC_F,              KC_G,              KC_H,              KC_J,              KC_K,              KC_L,              KC_QUOT,           \
@@ -240,6 +258,12 @@ U_NP,              U_NP,              KC_ESC,            KC_SPC,            KC_T
 #define MIRYOKU_ALTERNATIVES_TAP_QWERTY \
 KC_Q,              KC_W,              KC_E,              KC_R,              KC_T,              KC_Y,              KC_U,              KC_I,              KC_O,              KC_P,              \
 KC_A,              KC_S,              KC_D,              KC_F,              KC_G,              KC_H,              KC_J,              KC_K,              KC_L,              KC_QUOT,           \
+KC_Z,              KC_X,              KC_C,              KC_V,              KC_B,              KC_N,              KC_M,              KC_COMM,           KC_DOT,            KC_SLSH,           \
+U_NP,              U_NP,              KC_ESC,            KC_SPC,            KC_TAB,            KC_ENT,            KC_BSPC,           KC_DEL,            U_NP,              U_NP
+
+#define MIRYOKU_ALTERNATIVES_TAP_QWERTY_NORMAL \
+KC_Q,              KC_W,              KC_E,              KC_R,              KC_T,              KC_Y,              KC_U,              KC_I,              KC_O,              KC_P,              \
+KC_A,              KC_S,              KC_D,              KC_F,              KC_G,              KC_H,              KC_J,              KC_K,              KC_L,              KC_SCLN,           \
 KC_Z,              KC_X,              KC_C,              KC_V,              KC_B,              KC_N,              KC_M,              KC_COMM,           KC_DOT,            KC_SLSH,           \
 U_NP,              U_NP,              KC_ESC,            KC_SPC,            KC_TAB,            KC_ENT,            KC_BSPC,           KC_DEL,            U_NP,              U_NP
 

--- a/tangled/zmk/miryoku_layer_alternatives.h
+++ b/tangled/zmk/miryoku_layer_alternatives.h
@@ -60,6 +60,12 @@ U_NP,              U_NP,              &lt U_FUN DEL,     &lt U_NUM BSPC,    &lt 
 &lt U_BUTTON Z,    &hm RALT X,        &kp C,             &kp V,             &kp B,             &kp N,             &kp M,             &kp COMMA,         &hm RALT DOT,      &lt U_BUTTON SLASH,\
 U_NP,              U_NP,              &lt U_FUN DEL,     &lt U_NUM BSPC,    &lt U_SYM RET,     &lt U_MOUSE TAB,   &lt U_NAV SPC,     &lt U_MEDIA ESC,   U_NP,              U_NP
 
+#define MIRYOKU_ALTERNATIVES_BASE_QWERTY_NORMAL_FLIP \
+&kp Q,             &kp W,             &kp E,             &kp R,             &kp T,             &kp Y,             &kp U,             &kp I,             &kp O,             &kp P,             \
+&hm LGUI A,        &hm LALT S,        &hm LCTRL D,       &hm LSHFT F,       &kp G,             &kp H,             &hm LSHFT J,       &hm LCTRL K,       &hm LALT L,        &hm LGUI SEMI,     \
+&lt U_BUTTON Z,    &hm RALT X,        &kp C,             &kp V,             &kp B,             &kp N,             &kp M,             &kp COMMA,         &hm RALT DOT,      &lt U_BUTTON SLASH,\
+U_NP,              U_NP,              &lt U_FUN DEL,     &lt U_NUM BSPC,    &lt U_SYM RET,     &lt U_MOUSE TAB,   &lt U_NAV SPC,     &lt U_MEDIA ESC,   U_NP,              U_NP
+
 #define MIRYOKU_ALTERNATIVES_BASE_QWERTZ_FLIP \
 &kp Q,             &kp W,             &kp E,             &kp R,             &kp T,             &kp Z,             &kp U,             &kp I,             &kp O,             &kp P,             \
 &hm LGUI A,        &hm LALT S,        &hm LCTRL D,       &hm LSHFT F,       &kp G,             &kp H,             &hm LSHFT J,       &hm LCTRL K,       &hm LALT L,        &hm LGUI SQT,      \
@@ -117,6 +123,12 @@ U_NP,              U_NP,              &lt U_MEDIA ESC,   &lt U_NAV SPC,     &lt 
 #define MIRYOKU_ALTERNATIVES_BASE_QWERTY \
 &kp Q,             &kp W,             &kp E,             &kp R,             &kp T,             &kp Y,             &kp U,             &kp I,             &kp O,             &kp P,             \
 &hm LGUI A,        &hm LALT S,        &hm LCTRL D,       &hm LSHFT F,       &kp G,             &kp H,             &hm LSHFT J,       &hm LCTRL K,       &hm LALT L,        &hm LGUI SQT,      \
+&lt U_BUTTON Z,    &hm RALT X,        &kp C,             &kp V,             &kp B,             &kp N,             &kp M,             &kp COMMA,         &hm RALT DOT,      &lt U_BUTTON SLASH,\
+U_NP,              U_NP,              &lt U_MEDIA ESC,   &lt U_NAV SPC,     &lt U_MOUSE TAB,   &lt U_SYM RET,     &lt U_NUM BSPC,    &lt U_FUN DEL,     U_NP,              U_NP
+
+#define MIRYOKU_ALTERNATIVES_BASE_QWERTY_NORMAL \
+&kp Q,             &kp W,             &kp E,             &kp R,             &kp T,             &kp Y,             &kp U,             &kp I,             &kp O,             &kp P,             \
+&hm LGUI A,        &hm LALT S,        &hm LCTRL D,       &hm LSHFT F,       &kp G,             &kp H,             &hm LSHFT J,       &hm LCTRL K,       &hm LALT L,        &hm LGUI SEMI,     \
 &lt U_BUTTON Z,    &hm RALT X,        &kp C,             &kp V,             &kp B,             &kp N,             &kp M,             &kp COMMA,         &hm RALT DOT,      &lt U_BUTTON SLASH,\
 U_NP,              U_NP,              &lt U_MEDIA ESC,   &lt U_NAV SPC,     &lt U_MOUSE TAB,   &lt U_SYM RET,     &lt U_NUM BSPC,    &lt U_FUN DEL,     U_NP,              U_NP
 
@@ -181,6 +193,12 @@ U_NP,              U_NP,              &kp DEL,           &kp BSPC,          &kp 
 &kp Z,             &kp X,             &kp C,             &kp V,             &kp B,             &kp N,             &kp M,             &kp COMMA,         &kp DOT,           &kp SLASH,         \
 U_NP,              U_NP,              &kp DEL,           &kp BSPC,          &kp RET,           &kp TAB,           &kp SPC,           &kp ESC,           U_NP,              U_NP
 
+#define MIRYOKU_ALTERNATIVES_TAP_QWERTY_NORMAL_FLIP \
+&kp Q,             &kp W,             &kp E,             &kp R,             &kp T,             &kp Y,             &kp U,             &kp I,             &kp O,             &kp P,             \
+&kp A,             &kp S,             &kp D,             &kp F,             &kp G,             &kp H,             &kp J,             &kp K,             &kp L,             &kp SEMI,          \
+&kp Z,             &kp X,             &kp C,             &kp V,             &kp B,             &kp N,             &kp M,             &kp COMMA,         &kp DOT,           &kp SLASH,         \
+U_NP,              U_NP,              &kp DEL,           &kp BSPC,          &kp RET,           &kp TAB,           &kp SPC,           &kp ESC,           U_NP,              U_NP
+
 #define MIRYOKU_ALTERNATIVES_TAP_QWERTZ_FLIP \
 &kp Q,             &kp W,             &kp E,             &kp R,             &kp T,             &kp Z,             &kp U,             &kp I,             &kp O,             &kp P,             \
 &kp A,             &kp S,             &kp D,             &kp F,             &kp G,             &kp H,             &kp J,             &kp K,             &kp L,             &kp SQT,           \
@@ -238,6 +256,12 @@ U_NP,              U_NP,              &kp ESC,           &kp SPC,           &kp 
 #define MIRYOKU_ALTERNATIVES_TAP_QWERTY \
 &kp Q,             &kp W,             &kp E,             &kp R,             &kp T,             &kp Y,             &kp U,             &kp I,             &kp O,             &kp P,             \
 &kp A,             &kp S,             &kp D,             &kp F,             &kp G,             &kp H,             &kp J,             &kp K,             &kp L,             &kp SQT,           \
+&kp Z,             &kp X,             &kp C,             &kp V,             &kp B,             &kp N,             &kp M,             &kp COMMA,         &kp DOT,           &kp SLASH,         \
+U_NP,              U_NP,              &kp ESC,           &kp SPC,           &kp TAB,           &kp RET,           &kp BSPC,          &kp DEL,           U_NP,              U_NP
+
+#define MIRYOKU_ALTERNATIVES_TAP_QWERTY_NORMAL \
+&kp Q,             &kp W,             &kp E,             &kp R,             &kp T,             &kp Y,             &kp U,             &kp I,             &kp O,             &kp P,             \
+&kp A,             &kp S,             &kp D,             &kp F,             &kp G,             &kp H,             &kp J,             &kp K,             &kp L,             &kp SEMI,          \
 &kp Z,             &kp X,             &kp C,             &kp V,             &kp B,             &kp N,             &kp M,             &kp COMMA,         &kp DOT,           &kp SLASH,         \
 U_NP,              U_NP,              &kp ESC,           &kp SPC,           &kp TAB,           &kp RET,           &kp BSPC,          &kp DEL,           U_NP,              U_NP
 


### PR DESCRIPTION
This would be necessary in order to make a Swedish layout

Hi! Life had other distractions for a while - hope you don't mind :-)

This is continuing from to https://github.com/manna-harbour/miryoku/issues/35 and partly https://github.com/manna-harbour/miryoku/pull/106 - I'm now in the progress of building a whole set of Crkbd with colleagues. Myself I prefer the 3x10 Miryoku with EurKEY, but it would be nice to lower the threshold and actually achieve a "wide" Miryoku with symbols placed in sensible ways to be used with hosts set for Swedish mapping. No doubt this isn't the best way to solve it, but it was exciting to get Tangled [sic] and I figured I'd at least mention it