### PR TITLE
Strip whitespace to pacify test workflow

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -931,49 +931,49 @@ for half_row, hold_row in zip(half_table, hold_table):
   hold_row_l, hold_row_r = hold_row[:length], hold_row[length:]
   for lr, hold_row_lr in ('l', hold_row_l), ('r', hold_row_r):
     if lr == mode:
-	for half in half_row:
-	  code = half
-	  code = convert_symbol(code)
-          shifted_code = get_shifted(code)
-	  if shift == "true" and shifted_code != None:
-	    code = shifted_code
-	  elif target == 'svg' and shifted_code != None:
-            code = get_translated(code)
-            shifted_code = trim_shifted(code, shifted_code)
-	    code = 'U_S(' + str(wrap_basic(shifted_code)) + ', ' + str(wrap_basic(code)) +')'
-	  code = get_translated(code)
-	  if code == '':
-	    code = 'U_NU'
-	  code = wrap_basic(code)
-	  results += (str(code) + ',').ljust(width)
+      for half in half_row:
+        code = half
+        code = convert_symbol(code)
+        shifted_code = get_shifted(code)
+        if shift == "true" and shifted_code != None:
+          code = shifted_code
+        elif target == 'svg' and shifted_code != None:
+          code = get_translated(code)
+          shifted_code = trim_shifted(code, shifted_code)
+          code = 'U_S(' + str(wrap_basic(shifted_code)) + ', ' + str(wrap_basic(code)) +')'
+        code = get_translated(code)
+        if code == '':
+          code = 'U_NU'
+        code = wrap_basic(code)
+        results += (str(code) + ',').ljust(width)
     else:
-	for hold in hold_row_lr:
-	  if hold in mods_dict:
-	    code = wrap_basic(get_translated(hold))
-	  else:
-	    hold = get_translated(hold)
-	    if hold == '' or hold in layers_dict:
-	      code = 'U_NA'
-	      if target == 'svg' and hold == current_layer_name:
-		code = 'U_HELD(' + code + ')'
-	    elif hold == 'LOCK_CUR' or hold == 'LOCK_OPP':
-	      if hold == 'LOCK_CUR':
-		layer_name = current_layer_name
-	      else:
-		layer_name = opposite_layer_name
-	      if target == 'qmk':
-		code = 'TD(U_TD_' + layer_name + ')'
-	      elif target == 'zmk':
-		code = '&u_to_' + layer_name
-	      elif target == 'kmonad':
-		code = 'U_DF(' + layer_name + ')'
-	      elif target == 'svg':
-		code = 'U_DF(' + layer_name + ')'
-	      elif target == 'kmk':
-		code = 'U_DF(' + layer_name + ')'
-	    else:
-               code = wrap_basic(hold)
-	  results += (str(code) + ',').ljust(width)
+      for hold in hold_row_lr:
+        if hold in mods_dict:
+          code = wrap_basic(get_translated(hold))
+        else:
+          hold = get_translated(hold)
+          if hold == '' or hold in layers_dict:
+            code = 'U_NA'
+            if target == 'svg' and hold == current_layer_name:
+              code = 'U_HELD(' + code + ')'
+          elif hold == 'LOCK_CUR' or hold == 'LOCK_OPP':
+            if hold == 'LOCK_CUR':
+              layer_name = current_layer_name
+            else:
+              layer_name = opposite_layer_name
+            if target == 'qmk':
+              code = 'TD(U_TD_' + layer_name + ')'
+            elif target == 'zmk':
+              code = '&u_to_' + layer_name
+            elif target == 'kmonad':
+              code = 'U_DF(' + layer_name + ')'
+            elif target == 'svg':
+              code = 'U_DF(' + layer_name + ')'
+            elif target == 'kmk':
+              code = 'U_DF(' + layer_name + ')'
+          else:
+            code = wrap_basic(hold)
+        results += (str(code) + ',').ljust(width)
   results += '\\\n'
 results = results.rstrip(', \\\n')
 results

--- a/readme.org
+++ b/readme.org
@@ -1313,7 +1313,7 @@ for layer, name in layers_table:
   results += 'MIRYOKU_X(' + ( stripped + ', ').ljust(width)
   results += '"' + name + '"'
   results += ') \\\n'
-results = results.rstrip('\\\n')
+results = results.rstrip(' \\\n')
 return results
 #+END_SRC
 
@@ -1347,6 +1347,7 @@ for layer, name in layers_table:
   elif target == 'svg':
     results += '"' + name + '"' + '\n'
   i += 1
+results = results.rstrip('\n')
 return results
 #+END_SRC
 


### PR DESCRIPTION
In the upstream repo (manna-harbour/miryoku_babel), the test workflow succeeded the last time it ran (on ce22dc5814c2921adbe02943fc78fcab3f721159: https://github.com/manna-harbour/miryoku_babel/actions/runs/3636723534) but in my fork, it failed on the exact same commit, because of whitespace differences: https://github.com/jablko/miryoku_babel/actions/runs/6101254887/job/16557227170#step:9:56

I haven't dug into why it succeeded in the upstream repo or the last time it ran. I think the whitespace got introduced in https://github.com/manna-harbour/miryoku_babel/commit/45bfb70b0475a10533aca572cbcacca8c71bf13e#diff-7eafe228ddeb8e53e4c3b64b4ce1696b8127915a5720da227f9393e63cb2d47eR1150. This change, which just adds/edits `results.rstrip()` to eliminate that whitespace, makes the test workflow succeed.