### PR TITLE
Duplicate half-layer inner thumb to both hands

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -926,6 +926,7 @@ Produce sub layers from single hand and hold tables.
 #+NAME: table-layer-half
 #+BEGIN_SRC python :session :var hold_table=hold :var mode="r" :var half_table=media-r :var current_layer_name="U_MOUSE" :var opposite_layer_name="U_SYM" :var shift="false" :tangle no :results verbatim
 length = len(half_table[0])
+hold_table[-1][length - 1] = hold_table[-1][length] = convert_symbol(half_table[-1][-1 if mode == 'l' else 0])
 results = ''
 for half_row, hold_row in zip(half_table, hold_table):
   hold_row_l, hold_row_r = hold_row[:length], hold_row[length:]

--- a/tangled/kmk/miryoku_layer_alternatives.h
+++ b/tangled/kmk/miryoku_layer_alternatives.h
@@ -252,132 +252,132 @@ U_NP,              U_NP,              KC.ESC,            KC.SPC,            KC.T
 KC.PGUP,           KC.HOME,           KC.UP,             KC.END,            KC.INS,            U_NA,              U_DF(U_BASE),      U_DF(U_EXTRA),     U_DF(U_TAP),       U_BOOT,            \
 KC.PGDN,           KC.LEFT,           KC.DOWN,           KC.RGHT,           U_CW,              U_NA,              KC.LSFT,           KC.LCTL,           KC.LALT,           KC.LGUI,           \
 U_UND,             U_CUT,             U_CPY,             U_PST,             U_RDO,             U_NA,              U_DF(U_NAV),       U_DF(U_NUM),       KC.RALT,           U_NA,              \
-U_NP,              U_NP,              KC.DEL,            KC.BSPC,           KC.ENT,            U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              KC.DEL,            KC.BSPC,           KC.ENT,            KC.ENT,            U_NA,              U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_NAV_FLIP \
 KC.HOME,           KC.PGDN,           KC.PGUP,           KC.END,            KC.INS,            U_NA,              U_DF(U_BASE),      U_DF(U_EXTRA),     U_DF(U_TAP),       U_BOOT,            \
 KC.LEFT,           KC.DOWN,           KC.UP,             KC.RGHT,           U_CW,              U_NA,              KC.LSFT,           KC.LCTL,           KC.LALT,           KC.LGUI,           \
 U_UND,             U_CUT,             U_CPY,             U_PST,             U_RDO,             U_NA,              U_DF(U_NAV),       U_DF(U_NUM),       KC.RALT,           U_NA,              \
-U_NP,              U_NP,              KC.DEL,            KC.BSPC,           KC.ENT,            U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              KC.DEL,            KC.BSPC,           KC.ENT,            KC.ENT,            U_NA,              U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_NAV_INVERTEDT \
 U_BOOT,            U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              KC.INS,            KC.HOME,           KC.UP,             KC.END,            KC.PGUP,           \
 KC.LGUI,           KC.LALT,           KC.LCTL,           KC.LSFT,           U_NA,              U_CW,              KC.LEFT,           KC.DOWN,           KC.RGHT,           KC.PGDN,           \
 U_NA,              KC.RALT,           U_DF(U_NUM),       U_DF(U_NAV),       U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              KC.ENT,            KC.BSPC,           KC.DEL,            U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              KC.ENT,            KC.ENT,            KC.BSPC,           KC.DEL,            U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_NAV_VI \
 U_BOOT,            U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
 KC.LGUI,           KC.LALT,           KC.LCTL,           KC.LSFT,           U_NA,              KC.LEFT,           KC.DOWN,           KC.UP,             KC.RGHT,           U_CW,              \
 U_NA,              KC.RALT,           U_DF(U_NUM),       U_DF(U_NAV),       U_NA,              KC.HOME,           KC.PGDN,           KC.PGUP,           KC.END,            KC.INS,            \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              KC.ENT,            KC.BSPC,           KC.DEL,            U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              KC.ENT,            KC.ENT,            KC.BSPC,           KC.DEL,            U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_NAV \
 U_BOOT,            U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
 KC.LGUI,           KC.LALT,           KC.LCTL,           KC.LSFT,           U_NA,              U_CW,              KC.LEFT,           KC.DOWN,           KC.UP,             KC.RGHT,           \
 U_NA,              KC.RALT,           U_DF(U_NUM),       U_DF(U_NAV),       U_NA,              KC.INS,            KC.HOME,           KC.PGDN,           KC.PGUP,           KC.END,            \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              KC.ENT,            KC.BSPC,           KC.DEL,            U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              KC.ENT,            KC.ENT,            KC.BSPC,           KC.DEL,            U_NP,              U_NP
 
 
 #define MIRYOKU_ALTERNATIVES_MOUSE_INVERTEDT_FLIP \
 KC.MW_UP,          U_NU,              KC.MS_UP,          U_NU,              U_NU,              U_NA,              U_DF(U_BASE),      U_DF(U_EXTRA),     U_DF(U_TAP),       U_BOOT,            \
 KC.MW_DN,          KC.MS_LT,          KC.MS_DN,          KC.MS_RT,          U_NU,              U_NA,              KC.LSFT,           KC.LCTL,           KC.LALT,           KC.LGUI,           \
 U_UND,             U_CUT,             U_CPY,             U_PST,             U_RDO,             U_NA,              U_DF(U_MOUSE),     U_DF(U_SYM),       KC.RALT,           U_NA,              \
-U_NP,              U_NP,              KC.MB_MMB,         KC.MB_LMB,         KC.MB_RMB,         U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              KC.MB_MMB,         KC.MB_LMB,         KC.MB_RMB,         KC.MB_RMB,         U_NA,              U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MOUSE_FLIP \
 U_NU,              KC.MW_DN,          KC.MW_UP,          U_NU,              U_NU,              U_NA,              U_DF(U_BASE),      U_DF(U_EXTRA),     U_DF(U_TAP),       U_BOOT,            \
 KC.MS_LT,          KC.MS_DN,          KC.MS_UP,          KC.MS_RT,          U_NU,              U_NA,              KC.LSFT,           KC.LCTL,           KC.LALT,           KC.LGUI,           \
 U_UND,             U_CUT,             U_CPY,             U_PST,             U_RDO,             U_NA,              U_DF(U_MOUSE),     U_DF(U_SYM),       KC.RALT,           U_NA,              \
-U_NP,              U_NP,              KC.MB_MMB,         KC.MB_LMB,         KC.MB_RMB,         U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              KC.MB_MMB,         KC.MB_LMB,         KC.MB_RMB,         KC.MB_RMB,         U_NA,              U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MOUSE_INVERTEDT \
 U_BOOT,            U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              U_NU,              U_NU,              KC.MS_UP,          U_NU,              KC.MW_UP,          \
 KC.LGUI,           KC.LALT,           KC.LCTL,           KC.LSFT,           U_NA,              U_NU,              KC.MS_LT,          KC.MS_DN,          KC.MS_RT,          KC.MW_DN,          \
 U_NA,              KC.RALT,           U_DF(U_SYM),       U_DF(U_MOUSE),     U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              KC.MB_RMB,         KC.MB_LMB,         KC.MB_MMB,         U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              KC.MB_RMB,         KC.MB_RMB,         KC.MB_LMB,         KC.MB_MMB,         U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MOUSE_VI \
 U_BOOT,            U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
 KC.LGUI,           KC.LALT,           KC.LCTL,           KC.LSFT,           U_NA,              KC.MS_LT,          KC.MS_DN,          KC.MS_UP,          KC.MS_RT,          U_NU,              \
 U_NA,              KC.RALT,           U_DF(U_SYM),       U_DF(U_MOUSE),     U_NA,              U_NU,              KC.MW_DN,          KC.MW_UP,          U_NU,              U_NU,              \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              KC.MB_RMB,         KC.MB_LMB,         KC.MB_MMB,         U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              KC.MB_RMB,         KC.MB_RMB,         KC.MB_LMB,         KC.MB_MMB,         U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MOUSE \
 U_BOOT,            U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
 KC.LGUI,           KC.LALT,           KC.LCTL,           KC.LSFT,           U_NA,              U_NU,              KC.MS_LT,          KC.MS_DN,          KC.MS_UP,          KC.MS_RT,          \
 U_NA,              KC.RALT,           U_DF(U_SYM),       U_DF(U_MOUSE),     U_NA,              U_NU,              U_NU,              KC.MW_DN,          KC.MW_UP,          U_NU,              \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              KC.MB_RMB,         KC.MB_LMB,         KC.MB_MMB,         U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              KC.MB_RMB,         KC.MB_RMB,         KC.MB_LMB,         KC.MB_MMB,         U_NP,              U_NP
 
 
 #define MIRYOKU_ALTERNATIVES_MEDIA_INVERTEDT_FLIP \
 U_RGB_HUI,         U_RGB_SAI,         KC.VOLU,           U_RGB_VAI,         U_RGB_TOG,         U_NA,              U_DF(U_BASE),      U_DF(U_EXTRA),     U_DF(U_TAP),       U_BOOT,            \
 U_RGB_MOD,         KC.MPRV,           KC.VOLD,           KC.MNXT,           KC.PS_TOG,         U_NA,              KC.LSFT,           KC.LCTL,           KC.LALT,           KC.LGUI,           \
 U_NU,              U_NU,              U_NU,              U_NU,              KC.HID,            U_NA,              U_DF(U_MEDIA),     U_DF(U_FUN),       KC.RALT,           U_NA,              \
-U_NP,              U_NP,              KC.MUTE,           KC.MPLY,           KC.MSTP,           U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              KC.MUTE,           KC.MPLY,           KC.MSTP,           KC.MSTP,           U_NA,              U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MEDIA_FLIP \
 U_RGB_MOD,         U_RGB_HUI,         U_RGB_SAI,         U_RGB_VAI,         U_RGB_TOG,         U_NA,              U_DF(U_BASE),      U_DF(U_EXTRA),     U_DF(U_TAP),       U_BOOT,            \
 KC.MPRV,           KC.VOLD,           KC.VOLU,           KC.MNXT,           KC.PS_TOG,         U_NA,              KC.LSFT,           KC.LCTL,           KC.LALT,           KC.LGUI,           \
 U_NU,              U_NU,              U_NU,              U_NU,              KC.HID,            U_NA,              U_DF(U_MEDIA),     U_DF(U_FUN),       KC.RALT,           U_NA,              \
-U_NP,              U_NP,              KC.MUTE,           KC.MPLY,           KC.MSTP,           U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              KC.MUTE,           KC.MPLY,           KC.MSTP,           KC.MSTP,           U_NA,              U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MEDIA_INVERTEDT \
 U_BOOT,            U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              U_RGB_TOG,         U_RGB_MOD,         KC.VOLU,           U_RGB_HUI,         U_RGB_SAI,         \
 KC.LGUI,           KC.LALT,           KC.LCTL,           KC.LSFT,           U_NA,              KC.PS_TOG,         KC.MPRV,           KC.VOLD,           KC.MNXT,           U_RGB_VAI,         \
 U_NA,              KC.RALT,           U_DF(U_FUN),       U_DF(U_MEDIA),     U_NA,              KC.HID,            U_NU,              U_NU,              U_NU,              U_NU,              \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              KC.MSTP,           KC.MPLY,           KC.MUTE,           U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              KC.MSTP,           KC.MSTP,           KC.MPLY,           KC.MUTE,           U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MEDIA_VI \
 U_BOOT,            U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              U_RGB_MOD,         U_RGB_HUI,         U_RGB_SAI,         U_RGB_VAI,         U_RGB_TOG,         \
 KC.LGUI,           KC.LALT,           KC.LCTL,           KC.LSFT,           U_NA,              KC.MPRV,           KC.VOLD,           KC.VOLU,           KC.MNXT,           KC.PS_TOG,         \
 U_NA,              KC.RALT,           U_DF(U_FUN),       U_DF(U_MEDIA),     U_NA,              U_NU,              U_NU,              U_NU,              U_NU,              KC.HID,            \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              KC.MSTP,           KC.MPLY,           KC.MUTE,           U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              KC.MSTP,           KC.MSTP,           KC.MPLY,           KC.MUTE,           U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MEDIA \
 U_BOOT,            U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              U_RGB_TOG,         U_RGB_MOD,         U_RGB_HUI,         U_RGB_SAI,         U_RGB_VAI,         \
 KC.LGUI,           KC.LALT,           KC.LCTL,           KC.LSFT,           U_NA,              KC.PS_TOG,         KC.MPRV,           KC.VOLD,           KC.VOLU,           KC.MNXT,           \
 U_NA,              KC.RALT,           U_DF(U_FUN),       U_DF(U_MEDIA),     U_NA,              KC.HID,            U_NU,              U_NU,              U_NU,              U_NU,              \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              KC.MSTP,           KC.MPLY,           KC.MUTE,           U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              KC.MSTP,           KC.MSTP,           KC.MPLY,           KC.MUTE,           U_NP,              U_NP
 
 
 #define MIRYOKU_ALTERNATIVES_NUM_FLIP \
 U_BOOT,            U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              KC.LBRC,           KC.N7,             KC.N8,             KC.N9,             KC.RBRC,           \
 KC.LGUI,           KC.LALT,           KC.LCTL,           KC.LSFT,           U_NA,              KC.EQL,            KC.N4,             KC.N5,             KC.N6,             KC.SCLN,           \
 U_NA,              KC.RALT,           U_DF(U_NAV),       U_DF(U_NUM),       U_NA,              KC.BSLS,           KC.N1,             KC.N2,             KC.N3,             KC.GRV,            \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              KC.MINS,           KC.N0,             KC.DOT,            U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              KC.MINS,           KC.MINS,           KC.N0,             KC.DOT,            U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_NUM \
 KC.LBRC,           KC.N7,             KC.N8,             KC.N9,             KC.RBRC,           U_NA,              U_DF(U_BASE),      U_DF(U_EXTRA),     U_DF(U_TAP),       U_BOOT,            \
 KC.SCLN,           KC.N4,             KC.N5,             KC.N6,             KC.EQL,            U_NA,              KC.LSFT,           KC.LCTL,           KC.LALT,           KC.LGUI,           \
 KC.GRV,            KC.N1,             KC.N2,             KC.N3,             KC.BSLS,           U_NA,              U_DF(U_NUM),       U_DF(U_NAV),       KC.RALT,           U_NA,              \
-U_NP,              U_NP,              KC.DOT,            KC.N0,             KC.MINS,           U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              KC.DOT,            KC.N0,             KC.MINS,           KC.MINS,           U_NA,              U_NA,              U_NP,              U_NP
 
 
 #define MIRYOKU_ALTERNATIVES_SYM_FLIP \
 U_BOOT,            U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              KC.LCBR,           KC.AMPR,           KC.ASTR,           KC.LPRN,           KC.RCBR,           \
 KC.LGUI,           KC.LALT,           KC.LCTL,           KC.LSFT,           U_NA,              KC.PLUS,           KC.DLR,            KC.PERC,           KC.CIRC,           KC.COLN,           \
 U_NA,              KC.RALT,           U_DF(U_MOUSE),     U_DF(U_SYM),       U_NA,              KC.PIPE,           KC.EXLM,           KC.AT,             KC.HASH,           KC.TILD,           \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              KC.UNDS,           KC.LPRN,           KC.RPRN,           U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              KC.UNDS,           KC.UNDS,           KC.LPRN,           KC.RPRN,           U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_SYM \
 KC.LCBR,           KC.AMPR,           KC.ASTR,           KC.LPRN,           KC.RCBR,           U_NA,              U_DF(U_BASE),      U_DF(U_EXTRA),     U_DF(U_TAP),       U_BOOT,            \
 KC.COLN,           KC.DLR,            KC.PERC,           KC.CIRC,           KC.PLUS,           U_NA,              KC.LSFT,           KC.LCTL,           KC.LALT,           KC.LGUI,           \
 KC.TILD,           KC.EXLM,           KC.AT,             KC.HASH,           KC.PIPE,           U_NA,              U_DF(U_SYM),       U_DF(U_MOUSE),     KC.RALT,           U_NA,              \
-U_NP,              U_NP,              KC.LPRN,           KC.RPRN,           KC.UNDS,           U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              KC.LPRN,           KC.RPRN,           KC.UNDS,           KC.UNDS,           U_NA,              U_NA,              U_NP,              U_NP
 
 
 #define MIRYOKU_ALTERNATIVES_FUN_FLIP \
 U_BOOT,            U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              KC.PSCR,           KC.F7,             KC.F8,             KC.F9,             KC.F12,            \
 KC.LGUI,           KC.LALT,           KC.LCTL,           KC.LSFT,           U_NA,              KC.SLCK,           KC.F4,             KC.F5,             KC.F6,             KC.F11,            \
 U_NA,              KC.RALT,           U_DF(U_MEDIA),     U_DF(U_FUN),       U_NA,              KC.PAUS,           KC.F1,             KC.F2,             KC.F3,             KC.F10,            \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              KC.TAB,            KC.SPC,            KC.APP,            U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              KC.TAB,            KC.TAB,            KC.SPC,            KC.APP,            U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_FUN \
 KC.F12,            KC.F7,             KC.F8,             KC.F9,             KC.PSCR,           U_NA,              U_DF(U_BASE),      U_DF(U_EXTRA),     U_DF(U_TAP),       U_BOOT,            \
 KC.F11,            KC.F4,             KC.F5,             KC.F6,             KC.SLCK,           U_NA,              KC.LSFT,           KC.LCTL,           KC.LALT,           KC.LGUI,           \
 KC.F10,            KC.F1,             KC.F2,             KC.F3,             KC.PAUS,           U_NA,              U_DF(U_FUN),       U_DF(U_MEDIA),     KC.RALT,           U_NA,              \
-U_NP,              U_NP,              KC.APP,            KC.SPC,            KC.TAB,            U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              KC.APP,            KC.SPC,            KC.TAB,            KC.TAB,            U_NA,              U_NA,              U_NP,              U_NP
 
 
 #define MIRYOKU_ALTERNATIVES_BUTTON \

--- a/tangled/kmonad/miryoku_layer_alternatives.h
+++ b/tangled/kmonad/miryoku_layer_alternatives.h
@@ -252,132 +252,132 @@ U_NP,              U_NP,              esc,               spc,               tab,
 pgup,              home,              up,                end,               ins,               U_NA,              U_DF(U_BASE),      U_DF(U_EXTRA),     U_DF(U_TAP),       U_NA,              \
 pgdn,              left,              down,              right,             caps,              U_NA,              sft,               ctl,               alt,               met,               \
 U_UND,             U_CUT,             U_CPY,             U_PST,             U_RDO,             U_NA,              U_DF(U_NAV),       U_DF(U_NUM),       ralt,              U_NA,              \
-U_NP,              U_NP,              del,               bspc,              ent,               U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              del,               bspc,              ent,               ent,               U_NA,              U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_NAV_FLIP \
 home,              pgdn,              pgup,              end,               ins,               U_NA,              U_DF(U_BASE),      U_DF(U_EXTRA),     U_DF(U_TAP),       U_NA,              \
 left,              down,              up,                right,             caps,              U_NA,              sft,               ctl,               alt,               met,               \
 U_UND,             U_CUT,             U_CPY,             U_PST,             U_RDO,             U_NA,              U_DF(U_NAV),       U_DF(U_NUM),       ralt,              U_NA,              \
-U_NP,              U_NP,              del,               bspc,              ent,               U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              del,               bspc,              ent,               ent,               U_NA,              U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_NAV_INVERTEDT \
 U_NA,              U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              ins,               home,              up,                end,               pgup,              \
 met,               alt,               ctl,               sft,               U_NA,              caps,              left,              down,              right,             pgdn,              \
 U_NA,              ralt,              U_DF(U_NUM),       U_DF(U_NAV),       U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              ent,               bspc,              del,               U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              ent,               ent,               bspc,              del,               U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_NAV_VI \
 U_NA,              U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
 met,               alt,               ctl,               sft,               U_NA,              left,              down,              up,                right,             caps,              \
 U_NA,              ralt,              U_DF(U_NUM),       U_DF(U_NAV),       U_NA,              home,              pgdn,              pgup,              end,               ins,               \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              ent,               bspc,              del,               U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              ent,               ent,               bspc,              del,               U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_NAV \
 U_NA,              U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
 met,               alt,               ctl,               sft,               U_NA,              caps,              left,              down,              up,                right,             \
 U_NA,              ralt,              U_DF(U_NUM),       U_DF(U_NAV),       U_NA,              ins,               home,              pgdn,              pgup,              end,               \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              ent,               bspc,              del,               U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              ent,               ent,               bspc,              del,               U_NP,              U_NP
 
 
 #define MIRYOKU_ALTERNATIVES_MOUSE_INVERTEDT_FLIP \
 U_NU,              U_NU,              kp8,               U_NU,              U_NU,              U_NA,              U_DF(U_BASE),      U_DF(U_EXTRA),     U_DF(U_TAP),       U_NA,              \
 U_NU,              kp4,               kp2,               kp6,               U_NU,              U_NA,              sft,               ctl,               alt,               met,               \
 U_UND,             U_CUT,             U_CPY,             U_PST,             U_RDO,             U_NA,              U_DF(U_MOUSE),     U_DF(U_SYM),       ralt,              U_NA,              \
-U_NP,              U_NP,              #(kp* kp5),        #(kp/ kp5),        #(kp- kp5),        U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              #(kp* kp5),        #(kp/ kp5),        #(kp- kp5),        #(kp- kp5),        U_NA,              U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MOUSE_FLIP \
 U_NU,              U_NU,              U_NU,              U_NU,              U_NU,              U_NA,              U_DF(U_BASE),      U_DF(U_EXTRA),     U_DF(U_TAP),       U_NA,              \
 kp4,               kp2,               kp8,               kp6,               U_NU,              U_NA,              sft,               ctl,               alt,               met,               \
 U_UND,             U_CUT,             U_CPY,             U_PST,             U_RDO,             U_NA,              U_DF(U_MOUSE),     U_DF(U_SYM),       ralt,              U_NA,              \
-U_NP,              U_NP,              #(kp* kp5),        #(kp/ kp5),        #(kp- kp5),        U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              #(kp* kp5),        #(kp/ kp5),        #(kp- kp5),        #(kp- kp5),        U_NA,              U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MOUSE_INVERTEDT \
 U_NA,              U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              U_NU,              U_NU,              kp8,               U_NU,              U_NU,              \
 met,               alt,               ctl,               sft,               U_NA,              U_NU,              kp4,               kp2,               kp6,               U_NU,              \
 U_NA,              ralt,              U_DF(U_SYM),       U_DF(U_MOUSE),     U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              #(kp- kp5),        #(kp/ kp5),        #(kp* kp5),        U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              #(kp- kp5),        #(kp- kp5),        #(kp/ kp5),        #(kp* kp5),        U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MOUSE_VI \
 U_NA,              U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
 met,               alt,               ctl,               sft,               U_NA,              kp4,               kp2,               kp8,               kp6,               U_NU,              \
 U_NA,              ralt,              U_DF(U_SYM),       U_DF(U_MOUSE),     U_NA,              U_NU,              U_NU,              U_NU,              U_NU,              U_NU,              \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              #(kp- kp5),        #(kp/ kp5),        #(kp* kp5),        U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              #(kp- kp5),        #(kp- kp5),        #(kp/ kp5),        #(kp* kp5),        U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MOUSE \
 U_NA,              U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
 met,               alt,               ctl,               sft,               U_NA,              U_NU,              kp4,               kp2,               kp8,               kp6,               \
 U_NA,              ralt,              U_DF(U_SYM),       U_DF(U_MOUSE),     U_NA,              U_NU,              U_NU,              U_NU,              U_NU,              U_NU,              \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              #(kp- kp5),        #(kp/ kp5),        #(kp* kp5),        U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              #(kp- kp5),        #(kp- kp5),        #(kp/ kp5),        #(kp* kp5),        U_NP,              U_NP
 
 
 #define MIRYOKU_ALTERNATIVES_MEDIA_INVERTEDT_FLIP \
 U_NU,              U_NU,              volu,              U_NU,              U_NU,              U_NA,              U_DF(U_BASE),      U_DF(U_EXTRA),     U_DF(U_TAP),       U_NA,              \
 U_NU,              previoussong,      vold,              nextsong,          U_NU,              U_NA,              sft,               ctl,               alt,               met,               \
 U_NU,              U_NU,              U_NU,              U_NU,              U_NU,              U_NA,              U_DF(U_MEDIA),     U_DF(U_FUN),       ralt,              U_NA,              \
-U_NP,              U_NP,              mute,              playpause,         stopcd,            U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              mute,              playpause,         stopcd,            stopcd,            U_NA,              U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MEDIA_FLIP \
 U_NU,              U_NU,              U_NU,              U_NU,              U_NU,              U_NA,              U_DF(U_BASE),      U_DF(U_EXTRA),     U_DF(U_TAP),       U_NA,              \
 previoussong,      vold,              volu,              nextsong,          U_NU,              U_NA,              sft,               ctl,               alt,               met,               \
 U_NU,              U_NU,              U_NU,              U_NU,              U_NU,              U_NA,              U_DF(U_MEDIA),     U_DF(U_FUN),       ralt,              U_NA,              \
-U_NP,              U_NP,              mute,              playpause,         stopcd,            U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              mute,              playpause,         stopcd,            stopcd,            U_NA,              U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MEDIA_INVERTEDT \
 U_NA,              U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              U_NU,              U_NU,              volu,              U_NU,              U_NU,              \
 met,               alt,               ctl,               sft,               U_NA,              U_NU,              previoussong,      vold,              nextsong,          U_NU,              \
 U_NA,              ralt,              U_DF(U_FUN),       U_DF(U_MEDIA),     U_NA,              U_NU,              U_NU,              U_NU,              U_NU,              U_NU,              \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              stopcd,            playpause,         mute,              U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              stopcd,            stopcd,            playpause,         mute,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MEDIA_VI \
 U_NA,              U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              U_NU,              U_NU,              U_NU,              U_NU,              U_NU,              \
 met,               alt,               ctl,               sft,               U_NA,              previoussong,      vold,              volu,              nextsong,          U_NU,              \
 U_NA,              ralt,              U_DF(U_FUN),       U_DF(U_MEDIA),     U_NA,              U_NU,              U_NU,              U_NU,              U_NU,              U_NU,              \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              stopcd,            playpause,         mute,              U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              stopcd,            stopcd,            playpause,         mute,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MEDIA \
 U_NA,              U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              U_NU,              U_NU,              U_NU,              U_NU,              U_NU,              \
 met,               alt,               ctl,               sft,               U_NA,              U_NU,              previoussong,      vold,              volu,              nextsong,          \
 U_NA,              ralt,              U_DF(U_FUN),       U_DF(U_MEDIA),     U_NA,              U_NU,              U_NU,              U_NU,              U_NU,              U_NU,              \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              stopcd,            playpause,         mute,              U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              stopcd,            stopcd,            playpause,         mute,              U_NP,              U_NP
 
 
 #define MIRYOKU_ALTERNATIVES_NUM_FLIP \
 U_NA,              U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              [,                 7,                 8,                 9,                 ],                 \
 met,               alt,               ctl,               sft,               U_NA,              =,                 4,                 5,                 6,                 ;,                 \
 U_NA,              ralt,              U_DF(U_NAV),       U_DF(U_NUM),       U_NA,              \\,                1,                 2,                 3,                 `,                 \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              -,                 0,                 .,                 U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              -,                 -,                 0,                 .,                 U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_NUM \
 [,                 7,                 8,                 9,                 ],                 U_NA,              U_DF(U_BASE),      U_DF(U_EXTRA),     U_DF(U_TAP),       U_NA,              \
 ;,                 4,                 5,                 6,                 =,                 U_NA,              sft,               ctl,               alt,               met,               \
 `,                 1,                 2,                 3,                 \\,                U_NA,              U_DF(U_NUM),       U_DF(U_NAV),       ralt,              U_NA,              \
-U_NP,              U_NP,              .,                 0,                 -,                 U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              .,                 0,                 -,                 -,                 U_NA,              U_NA,              U_NP,              U_NP
 
 
 #define MIRYOKU_ALTERNATIVES_SYM_FLIP \
 U_NA,              U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              {,                 &,                 *,                 U_LPRN,            },                 \
 met,               alt,               ctl,               sft,               U_NA,              +,                 $,                 %,                 ^,                 :,                 \
 U_NA,              ralt,              U_DF(U_MOUSE),     U_DF(U_SYM),       U_NA,              U_PIPE,            !,                 @,                 #,                 ~,                 \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              \_,                U_LPRN,            U_RPRN,            U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              \_,                \_,                U_LPRN,            U_RPRN,            U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_SYM \
 {,                 &,                 *,                 U_LPRN,            },                 U_NA,              U_DF(U_BASE),      U_DF(U_EXTRA),     U_DF(U_TAP),       U_NA,              \
 :,                 $,                 %,                 ^,                 +,                 U_NA,              sft,               ctl,               alt,               met,               \
 ~,                 !,                 @,                 #,                 U_PIPE,            U_NA,              U_DF(U_SYM),       U_DF(U_MOUSE),     ralt,              U_NA,              \
-U_NP,              U_NP,              U_LPRN,            U_RPRN,            \_,                U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              U_LPRN,            U_RPRN,            \_,                \_,                U_NA,              U_NA,              U_NP,              U_NP
 
 
 #define MIRYOKU_ALTERNATIVES_FUN_FLIP \
 U_NA,              U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              sysrq,             f7,                f8,                f9,                f12,               \
 met,               alt,               ctl,               sft,               U_NA,              slck,              f4,                f5,                f6,                f11,               \
 U_NA,              ralt,              U_DF(U_MEDIA),     U_DF(U_FUN),       U_NA,              pause,             f1,                f2,                f3,                f10,               \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              tab,               spc,               comp,              U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              tab,               tab,               spc,               comp,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_FUN \
 f12,               f7,                f8,                f9,                sysrq,             U_NA,              U_DF(U_BASE),      U_DF(U_EXTRA),     U_DF(U_TAP),       U_NA,              \
 f11,               f4,                f5,                f6,                slck,              U_NA,              sft,               ctl,               alt,               met,               \
 f10,               f1,                f2,                f3,                pause,             U_NA,              U_DF(U_FUN),       U_DF(U_MEDIA),     ralt,              U_NA,              \
-U_NP,              U_NP,              comp,              spc,               tab,               U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              comp,              spc,               tab,               tab,               U_NA,              U_NA,              U_NP,              U_NP
 
 
 #define MIRYOKU_ALTERNATIVES_BUTTON \

--- a/tangled/qmk/miryoku_layer_alternatives.h
+++ b/tangled/qmk/miryoku_layer_alternatives.h
@@ -254,132 +254,132 @@ U_NP,              U_NP,              KC_ESC,            KC_SPC,            KC_T
 KC_PGUP,           KC_HOME,           KC_UP,             KC_END,            KC_INS,            U_NA,              TD(U_TD_U_BASE),   TD(U_TD_U_EXTRA),  TD(U_TD_U_TAP),    TD(U_TD_BOOT),     \
 KC_PGDN,           KC_LEFT,           KC_DOWN,           KC_RGHT,           CW_TOGG,           U_NA,              KC_LSFT,           KC_LCTL,           KC_LALT,           KC_LGUI,           \
 U_UND,             U_CUT,             U_CPY,             U_PST,             U_RDO,             U_NA,              TD(U_TD_U_NAV),    TD(U_TD_U_NUM),    KC_ALGR,           U_NA,              \
-U_NP,              U_NP,              KC_DEL,            KC_BSPC,           KC_ENT,            U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              KC_DEL,            KC_BSPC,           KC_ENT,            KC_ENT,            U_NA,              U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_NAV_FLIP \
 KC_HOME,           KC_PGDN,           KC_PGUP,           KC_END,            KC_INS,            U_NA,              TD(U_TD_U_BASE),   TD(U_TD_U_EXTRA),  TD(U_TD_U_TAP),    TD(U_TD_BOOT),     \
 KC_LEFT,           KC_DOWN,           KC_UP,             KC_RGHT,           CW_TOGG,           U_NA,              KC_LSFT,           KC_LCTL,           KC_LALT,           KC_LGUI,           \
 U_UND,             U_CUT,             U_CPY,             U_PST,             U_RDO,             U_NA,              TD(U_TD_U_NAV),    TD(U_TD_U_NUM),    KC_ALGR,           U_NA,              \
-U_NP,              U_NP,              KC_DEL,            KC_BSPC,           KC_ENT,            U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              KC_DEL,            KC_BSPC,           KC_ENT,            KC_ENT,            U_NA,              U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_NAV_INVERTEDT \
 TD(U_TD_BOOT),     TD(U_TD_U_TAP),    TD(U_TD_U_EXTRA),  TD(U_TD_U_BASE),   U_NA,              KC_INS,            KC_HOME,           KC_UP,             KC_END,            KC_PGUP,           \
 KC_LGUI,           KC_LALT,           KC_LCTL,           KC_LSFT,           U_NA,              CW_TOGG,           KC_LEFT,           KC_DOWN,           KC_RGHT,           KC_PGDN,           \
 U_NA,              KC_ALGR,           TD(U_TD_U_NUM),    TD(U_TD_U_NAV),    U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              KC_ENT,            KC_BSPC,           KC_DEL,            U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              KC_ENT,            KC_ENT,            KC_BSPC,           KC_DEL,            U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_NAV_VI \
 TD(U_TD_BOOT),     TD(U_TD_U_TAP),    TD(U_TD_U_EXTRA),  TD(U_TD_U_BASE),   U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
 KC_LGUI,           KC_LALT,           KC_LCTL,           KC_LSFT,           U_NA,              KC_LEFT,           KC_DOWN,           KC_UP,             KC_RGHT,           CW_TOGG,           \
 U_NA,              KC_ALGR,           TD(U_TD_U_NUM),    TD(U_TD_U_NAV),    U_NA,              KC_HOME,           KC_PGDN,           KC_PGUP,           KC_END,            KC_INS,            \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              KC_ENT,            KC_BSPC,           KC_DEL,            U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              KC_ENT,            KC_ENT,            KC_BSPC,           KC_DEL,            U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_NAV \
 TD(U_TD_BOOT),     TD(U_TD_U_TAP),    TD(U_TD_U_EXTRA),  TD(U_TD_U_BASE),   U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
 KC_LGUI,           KC_LALT,           KC_LCTL,           KC_LSFT,           U_NA,              CW_TOGG,           KC_LEFT,           KC_DOWN,           KC_UP,             KC_RGHT,           \
 U_NA,              KC_ALGR,           TD(U_TD_U_NUM),    TD(U_TD_U_NAV),    U_NA,              KC_INS,            KC_HOME,           KC_PGDN,           KC_PGUP,           KC_END,            \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              KC_ENT,            KC_BSPC,           KC_DEL,            U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              KC_ENT,            KC_ENT,            KC_BSPC,           KC_DEL,            U_NP,              U_NP
 
 
 #define MIRYOKU_ALTERNATIVES_MOUSE_INVERTEDT_FLIP \
 KC_WH_U,           KC_WH_L,           KC_MS_U,           KC_WH_R,           U_NU,              U_NA,              TD(U_TD_U_BASE),   TD(U_TD_U_EXTRA),  TD(U_TD_U_TAP),    TD(U_TD_BOOT),     \
 KC_WH_D,           KC_MS_L,           KC_MS_D,           KC_MS_R,           U_NU,              U_NA,              KC_LSFT,           KC_LCTL,           KC_LALT,           KC_LGUI,           \
 U_UND,             U_CUT,             U_CPY,             U_PST,             U_RDO,             U_NA,              TD(U_TD_U_MOUSE),  TD(U_TD_U_SYM),    KC_ALGR,           U_NA,              \
-U_NP,              U_NP,              KC_BTN3,           KC_BTN1,           KC_BTN2,           U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              KC_BTN3,           KC_BTN1,           KC_BTN2,           KC_BTN2,           U_NA,              U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MOUSE_FLIP \
 KC_WH_L,           KC_WH_D,           KC_WH_U,           KC_WH_R,           U_NU,              U_NA,              TD(U_TD_U_BASE),   TD(U_TD_U_EXTRA),  TD(U_TD_U_TAP),    TD(U_TD_BOOT),     \
 KC_MS_L,           KC_MS_D,           KC_MS_U,           KC_MS_R,           U_NU,              U_NA,              KC_LSFT,           KC_LCTL,           KC_LALT,           KC_LGUI,           \
 U_UND,             U_CUT,             U_CPY,             U_PST,             U_RDO,             U_NA,              TD(U_TD_U_MOUSE),  TD(U_TD_U_SYM),    KC_ALGR,           U_NA,              \
-U_NP,              U_NP,              KC_BTN3,           KC_BTN1,           KC_BTN2,           U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              KC_BTN3,           KC_BTN1,           KC_BTN2,           KC_BTN2,           U_NA,              U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MOUSE_INVERTEDT \
 TD(U_TD_BOOT),     TD(U_TD_U_TAP),    TD(U_TD_U_EXTRA),  TD(U_TD_U_BASE),   U_NA,              U_NU,              KC_WH_L,           KC_MS_U,           KC_WH_R,           KC_WH_U,           \
 KC_LGUI,           KC_LALT,           KC_LCTL,           KC_LSFT,           U_NA,              U_NU,              KC_MS_L,           KC_MS_D,           KC_MS_R,           KC_WH_D,           \
 U_NA,              KC_ALGR,           TD(U_TD_U_SYM),    TD(U_TD_U_MOUSE),  U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              KC_BTN2,           KC_BTN1,           KC_BTN3,           U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              KC_BTN2,           KC_BTN2,           KC_BTN1,           KC_BTN3,           U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MOUSE_VI \
 TD(U_TD_BOOT),     TD(U_TD_U_TAP),    TD(U_TD_U_EXTRA),  TD(U_TD_U_BASE),   U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
 KC_LGUI,           KC_LALT,           KC_LCTL,           KC_LSFT,           U_NA,              KC_MS_L,           KC_MS_D,           KC_MS_U,           KC_MS_R,           U_NU,              \
 U_NA,              KC_ALGR,           TD(U_TD_U_SYM),    TD(U_TD_U_MOUSE),  U_NA,              KC_WH_L,           KC_WH_D,           KC_WH_U,           KC_WH_R,           U_NU,              \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              KC_BTN2,           KC_BTN1,           KC_BTN3,           U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              KC_BTN2,           KC_BTN2,           KC_BTN1,           KC_BTN3,           U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MOUSE \
 TD(U_TD_BOOT),     TD(U_TD_U_TAP),    TD(U_TD_U_EXTRA),  TD(U_TD_U_BASE),   U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
 KC_LGUI,           KC_LALT,           KC_LCTL,           KC_LSFT,           U_NA,              U_NU,              KC_MS_L,           KC_MS_D,           KC_MS_U,           KC_MS_R,           \
 U_NA,              KC_ALGR,           TD(U_TD_U_SYM),    TD(U_TD_U_MOUSE),  U_NA,              U_NU,              KC_WH_L,           KC_WH_D,           KC_WH_U,           KC_WH_R,           \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              KC_BTN2,           KC_BTN1,           KC_BTN3,           U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              KC_BTN2,           KC_BTN2,           KC_BTN1,           KC_BTN3,           U_NP,              U_NP
 
 
 #define MIRYOKU_ALTERNATIVES_MEDIA_INVERTEDT_FLIP \
 RGB_HUI,           RGB_SAI,           KC_VOLU,           RGB_VAI,           RGB_TOG,           U_NA,              TD(U_TD_U_BASE),   TD(U_TD_U_EXTRA),  TD(U_TD_U_TAP),    TD(U_TD_BOOT),     \
 RGB_MOD,           KC_MPRV,           KC_VOLD,           KC_MNXT,           U_NU,              U_NA,              KC_LSFT,           KC_LCTL,           KC_LALT,           KC_LGUI,           \
 U_NU,              U_NU,              U_NU,              U_NU,              OU_AUTO,           U_NA,              TD(U_TD_U_MEDIA),  TD(U_TD_U_FUN),    KC_ALGR,           U_NA,              \
-U_NP,              U_NP,              KC_MUTE,           KC_MPLY,           KC_MSTP,           U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              KC_MUTE,           KC_MPLY,           KC_MSTP,           KC_MSTP,           U_NA,              U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MEDIA_FLIP \
 RGB_MOD,           RGB_HUI,           RGB_SAI,           RGB_VAI,           RGB_TOG,           U_NA,              TD(U_TD_U_BASE),   TD(U_TD_U_EXTRA),  TD(U_TD_U_TAP),    TD(U_TD_BOOT),     \
 KC_MPRV,           KC_VOLD,           KC_VOLU,           KC_MNXT,           U_NU,              U_NA,              KC_LSFT,           KC_LCTL,           KC_LALT,           KC_LGUI,           \
 U_NU,              U_NU,              U_NU,              U_NU,              OU_AUTO,           U_NA,              TD(U_TD_U_MEDIA),  TD(U_TD_U_FUN),    KC_ALGR,           U_NA,              \
-U_NP,              U_NP,              KC_MUTE,           KC_MPLY,           KC_MSTP,           U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              KC_MUTE,           KC_MPLY,           KC_MSTP,           KC_MSTP,           U_NA,              U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MEDIA_INVERTEDT \
 TD(U_TD_BOOT),     TD(U_TD_U_TAP),    TD(U_TD_U_EXTRA),  TD(U_TD_U_BASE),   U_NA,              RGB_TOG,           RGB_MOD,           KC_VOLU,           RGB_HUI,           RGB_SAI,           \
 KC_LGUI,           KC_LALT,           KC_LCTL,           KC_LSFT,           U_NA,              U_NU,              KC_MPRV,           KC_VOLD,           KC_MNXT,           RGB_VAI,           \
 U_NA,              KC_ALGR,           TD(U_TD_U_FUN),    TD(U_TD_U_MEDIA),  U_NA,              OU_AUTO,           U_NU,              U_NU,              U_NU,              U_NU,              \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              KC_MSTP,           KC_MPLY,           KC_MUTE,           U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              KC_MSTP,           KC_MSTP,           KC_MPLY,           KC_MUTE,           U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MEDIA_VI \
 TD(U_TD_BOOT),     TD(U_TD_U_TAP),    TD(U_TD_U_EXTRA),  TD(U_TD_U_BASE),   U_NA,              RGB_MOD,           RGB_HUI,           RGB_SAI,           RGB_VAI,           RGB_TOG,           \
 KC_LGUI,           KC_LALT,           KC_LCTL,           KC_LSFT,           U_NA,              KC_MPRV,           KC_VOLD,           KC_VOLU,           KC_MNXT,           U_NU,              \
 U_NA,              KC_ALGR,           TD(U_TD_U_FUN),    TD(U_TD_U_MEDIA),  U_NA,              U_NU,              U_NU,              U_NU,              U_NU,              OU_AUTO,           \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              KC_MSTP,           KC_MPLY,           KC_MUTE,           U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              KC_MSTP,           KC_MSTP,           KC_MPLY,           KC_MUTE,           U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MEDIA \
 TD(U_TD_BOOT),     TD(U_TD_U_TAP),    TD(U_TD_U_EXTRA),  TD(U_TD_U_BASE),   U_NA,              RGB_TOG,           RGB_MOD,           RGB_HUI,           RGB_SAI,           RGB_VAI,           \
 KC_LGUI,           KC_LALT,           KC_LCTL,           KC_LSFT,           U_NA,              U_NU,              KC_MPRV,           KC_VOLD,           KC_VOLU,           KC_MNXT,           \
 U_NA,              KC_ALGR,           TD(U_TD_U_FUN),    TD(U_TD_U_MEDIA),  U_NA,              OU_AUTO,           U_NU,              U_NU,              U_NU,              U_NU,              \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              KC_MSTP,           KC_MPLY,           KC_MUTE,           U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              KC_MSTP,           KC_MSTP,           KC_MPLY,           KC_MUTE,           U_NP,              U_NP
 
 
 #define MIRYOKU_ALTERNATIVES_NUM_FLIP \
 TD(U_TD_BOOT),     TD(U_TD_U_TAP),    TD(U_TD_U_EXTRA),  TD(U_TD_U_BASE),   U_NA,              KC_LBRC,           KC_7,              KC_8,              KC_9,              KC_RBRC,           \
 KC_LGUI,           KC_LALT,           KC_LCTL,           KC_LSFT,           U_NA,              KC_EQL,            KC_4,              KC_5,              KC_6,              KC_SCLN,           \
 U_NA,              KC_ALGR,           TD(U_TD_U_NAV),    TD(U_TD_U_NUM),    U_NA,              KC_BSLS,           KC_1,              KC_2,              KC_3,              KC_GRV,            \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              KC_MINS,           KC_0,              KC_DOT,            U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              KC_MINS,           KC_MINS,           KC_0,              KC_DOT,            U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_NUM \
 KC_LBRC,           KC_7,              KC_8,              KC_9,              KC_RBRC,           U_NA,              TD(U_TD_U_BASE),   TD(U_TD_U_EXTRA),  TD(U_TD_U_TAP),    TD(U_TD_BOOT),     \
 KC_SCLN,           KC_4,              KC_5,              KC_6,              KC_EQL,            U_NA,              KC_LSFT,           KC_LCTL,           KC_LALT,           KC_LGUI,           \
 KC_GRV,            KC_1,              KC_2,              KC_3,              KC_BSLS,           U_NA,              TD(U_TD_U_NUM),    TD(U_TD_U_NAV),    KC_ALGR,           U_NA,              \
-U_NP,              U_NP,              KC_DOT,            KC_0,              KC_MINS,           U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              KC_DOT,            KC_0,              KC_MINS,           KC_MINS,           U_NA,              U_NA,              U_NP,              U_NP
 
 
 #define MIRYOKU_ALTERNATIVES_SYM_FLIP \
 TD(U_TD_BOOT),     TD(U_TD_U_TAP),    TD(U_TD_U_EXTRA),  TD(U_TD_U_BASE),   U_NA,              KC_LCBR,           KC_AMPR,           KC_ASTR,           KC_LPRN,           KC_RCBR,           \
 KC_LGUI,           KC_LALT,           KC_LCTL,           KC_LSFT,           U_NA,              KC_PLUS,           KC_DLR,            KC_PERC,           KC_CIRC,           KC_COLN,           \
 U_NA,              KC_ALGR,           TD(U_TD_U_MOUSE),  TD(U_TD_U_SYM),    U_NA,              KC_PIPE,           KC_EXLM,           KC_AT,             KC_HASH,           KC_TILD,           \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              KC_UNDS,           KC_LPRN,           KC_RPRN,           U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              KC_UNDS,           KC_UNDS,           KC_LPRN,           KC_RPRN,           U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_SYM \
 KC_LCBR,           KC_AMPR,           KC_ASTR,           KC_LPRN,           KC_RCBR,           U_NA,              TD(U_TD_U_BASE),   TD(U_TD_U_EXTRA),  TD(U_TD_U_TAP),    TD(U_TD_BOOT),     \
 KC_COLN,           KC_DLR,            KC_PERC,           KC_CIRC,           KC_PLUS,           U_NA,              KC_LSFT,           KC_LCTL,           KC_LALT,           KC_LGUI,           \
 KC_TILD,           KC_EXLM,           KC_AT,             KC_HASH,           KC_PIPE,           U_NA,              TD(U_TD_U_SYM),    TD(U_TD_U_MOUSE),  KC_ALGR,           U_NA,              \
-U_NP,              U_NP,              KC_LPRN,           KC_RPRN,           KC_UNDS,           U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              KC_LPRN,           KC_RPRN,           KC_UNDS,           KC_UNDS,           U_NA,              U_NA,              U_NP,              U_NP
 
 
 #define MIRYOKU_ALTERNATIVES_FUN_FLIP \
 TD(U_TD_BOOT),     TD(U_TD_U_TAP),    TD(U_TD_U_EXTRA),  TD(U_TD_U_BASE),   U_NA,              KC_PSCR,           KC_F7,             KC_F8,             KC_F9,             KC_F12,            \
 KC_LGUI,           KC_LALT,           KC_LCTL,           KC_LSFT,           U_NA,              KC_SCRL,           KC_F4,             KC_F5,             KC_F6,             KC_F11,            \
 U_NA,              KC_ALGR,           TD(U_TD_U_MEDIA),  TD(U_TD_U_FUN),    U_NA,              KC_PAUS,           KC_F1,             KC_F2,             KC_F3,             KC_F10,            \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              KC_TAB,            KC_SPC,            KC_APP,            U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              KC_TAB,            KC_TAB,            KC_SPC,            KC_APP,            U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_FUN \
 KC_F12,            KC_F7,             KC_F8,             KC_F9,             KC_PSCR,           U_NA,              TD(U_TD_U_BASE),   TD(U_TD_U_EXTRA),  TD(U_TD_U_TAP),    TD(U_TD_BOOT),     \
 KC_F11,            KC_F4,             KC_F5,             KC_F6,             KC_SCRL,           U_NA,              KC_LSFT,           KC_LCTL,           KC_LALT,           KC_LGUI,           \
 KC_F10,            KC_F1,             KC_F2,             KC_F3,             KC_PAUS,           U_NA,              TD(U_TD_U_FUN),    TD(U_TD_U_MEDIA),  KC_ALGR,           U_NA,              \
-U_NP,              U_NP,              KC_APP,            KC_SPC,            KC_TAB,            U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              KC_APP,            KC_SPC,            KC_TAB,            KC_TAB,            U_NA,              U_NA,              U_NP,              U_NP
 
 
 #define MIRYOKU_ALTERNATIVES_BUTTON \

--- a/tangled/svg/miryoku_layer_alternatives.h
+++ b/tangled/svg/miryoku_layer_alternatives.h
@@ -252,132 +252,132 @@ U_NP,              U_NP,              "Esc",             "Space",           "Tab
 "Page Up",         "Home",            "Up",              "End",             "Insert",          U_NA,              U_DF(U_BASE),      U_DF(U_EXTRA),     U_DF(U_TAP),       U_BOOT,            \
 "Page Down",       "Left",            "Down",            "Right",           U_S("Lock", "Caps Word"),U_NA,              "Shift",           "Ctrl",            "Alt",             "Meta",            \
 U_UND,             U_CUT,             U_CPY,             U_PST,             U_RDO,             U_NA,              U_DF(U_NAV),       U_DF(U_NUM),       "AltGr",           U_NA,              \
-U_NP,              U_NP,              "Delete",          "Back Space",      "Enter",           U_NA,              U_HELD(U_NA),      U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              "Delete",          "Back Space",      "Enter",           "Enter",           U_HELD(U_NA),      U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_NAV_FLIP \
 "Home",            "Page Down",       "Page Up",         "End",             "Insert",          U_NA,              U_DF(U_BASE),      U_DF(U_EXTRA),     U_DF(U_TAP),       U_BOOT,            \
 "Left",            "Down",            "Up",              "Right",           U_S("Lock", "Caps Word"),U_NA,              "Shift",           "Ctrl",            "Alt",             "Meta",            \
 U_UND,             U_CUT,             U_CPY,             U_PST,             U_RDO,             U_NA,              U_DF(U_NAV),       U_DF(U_NUM),       "AltGr",           U_NA,              \
-U_NP,              U_NP,              "Delete",          "Back Space",      "Enter",           U_NA,              U_HELD(U_NA),      U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              "Delete",          "Back Space",      "Enter",           "Enter",           U_HELD(U_NA),      U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_NAV_INVERTEDT \
 U_BOOT,            U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              "Insert",          "Home",            "Up",              "End",             "Page Up",         \
 "Meta",            "Alt",             "Ctrl",            "Shift",           U_NA,              U_S("Lock", "Caps Word"),"Left",            "Down",            "Right",           "Page Down",       \
 U_NA,              "AltGr",           U_DF(U_NUM),       U_DF(U_NAV),       U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
-U_NP,              U_NP,              U_NA,              U_HELD(U_NA),      U_NA,              "Enter",           "Back Space",      "Delete",          U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_HELD(U_NA),      "Enter",           "Enter",           "Back Space",      "Delete",          U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_NAV_VI \
 U_BOOT,            U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
 "Meta",            "Alt",             "Ctrl",            "Shift",           U_NA,              "Left",            "Down",            "Up",              "Right",           U_S("Lock", "Caps Word"),\
 U_NA,              "AltGr",           U_DF(U_NUM),       U_DF(U_NAV),       U_NA,              "Home",            "Page Down",       "Page Up",         "End",             "Insert",          \
-U_NP,              U_NP,              U_NA,              U_HELD(U_NA),      U_NA,              "Enter",           "Back Space",      "Delete",          U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_HELD(U_NA),      "Enter",           "Enter",           "Back Space",      "Delete",          U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_NAV \
 U_BOOT,            U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
 "Meta",            "Alt",             "Ctrl",            "Shift",           U_NA,              U_S("Lock", "Caps Word"),"Left",            "Down",            "Up",              "Right",           \
 U_NA,              "AltGr",           U_DF(U_NUM),       U_DF(U_NAV),       U_NA,              "Insert",          "Home",            "Page Down",       "Page Up",         "End",             \
-U_NP,              U_NP,              U_NA,              U_HELD(U_NA),      U_NA,              "Enter",           "Back Space",      "Delete",          U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_HELD(U_NA),      "Enter",           "Enter",           "Back Space",      "Delete",          U_NP,              U_NP
 
 
 #define MIRYOKU_ALTERNATIVES_MOUSE_INVERTEDT_FLIP \
 "Scroll Up",       "Scroll Left",     "Mouse Up",        "Scroll Right",    U_NU,              U_NA,              U_DF(U_BASE),      U_DF(U_EXTRA),     U_DF(U_TAP),       U_BOOT,            \
 "Scroll Down",     "Mouse Left",      "Mouse Down",      "Mouse Right",     U_NU,              U_NA,              "Shift",           "Ctrl",            "Alt",             "Meta",            \
 U_UND,             U_CUT,             U_CPY,             U_PST,             U_RDO,             U_NA,              U_DF(U_MOUSE),     U_DF(U_SYM),       "AltGr",           U_NA,              \
-U_NP,              U_NP,              "Middle Button",   "Left Button",     "Right Button",    U_HELD(U_NA),      U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              "Middle Button",   "Left Button",     "Right Button",    "Right Button",    U_NA,              U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MOUSE_FLIP \
 "Scroll Left",     "Scroll Down",     "Scroll Up",       "Scroll Right",    U_NU,              U_NA,              U_DF(U_BASE),      U_DF(U_EXTRA),     U_DF(U_TAP),       U_BOOT,            \
 "Mouse Left",      "Mouse Down",      "Mouse Up",        "Mouse Right",     U_NU,              U_NA,              "Shift",           "Ctrl",            "Alt",             "Meta",            \
 U_UND,             U_CUT,             U_CPY,             U_PST,             U_RDO,             U_NA,              U_DF(U_MOUSE),     U_DF(U_SYM),       "AltGr",           U_NA,              \
-U_NP,              U_NP,              "Middle Button",   "Left Button",     "Right Button",    U_HELD(U_NA),      U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              "Middle Button",   "Left Button",     "Right Button",    "Right Button",    U_NA,              U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MOUSE_INVERTEDT \
 U_BOOT,            U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              U_NU,              "Scroll Left",     "Mouse Up",        "Scroll Right",    "Scroll Up",       \
 "Meta",            "Alt",             "Ctrl",            "Shift",           U_NA,              U_NU,              "Mouse Left",      "Mouse Down",      "Mouse Right",     "Scroll Down",     \
 U_NA,              "AltGr",           U_DF(U_SYM),       U_DF(U_MOUSE),     U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
-U_NP,              U_NP,              U_NA,              U_NA,              U_HELD(U_NA),      "Right Button",    "Left Button",     "Middle Button",   U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              "Right Button",    "Right Button",    "Left Button",     "Middle Button",   U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MOUSE_VI \
 U_BOOT,            U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
 "Meta",            "Alt",             "Ctrl",            "Shift",           U_NA,              "Mouse Left",      "Mouse Down",      "Mouse Up",        "Mouse Right",     U_NU,              \
 U_NA,              "AltGr",           U_DF(U_SYM),       U_DF(U_MOUSE),     U_NA,              "Scroll Left",     "Scroll Down",     "Scroll Up",       "Scroll Right",    U_NU,              \
-U_NP,              U_NP,              U_NA,              U_NA,              U_HELD(U_NA),      "Right Button",    "Left Button",     "Middle Button",   U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              "Right Button",    "Right Button",    "Left Button",     "Middle Button",   U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MOUSE \
 U_BOOT,            U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
 "Meta",            "Alt",             "Ctrl",            "Shift",           U_NA,              U_NU,              "Mouse Left",      "Mouse Down",      "Mouse Up",        "Mouse Right",     \
 U_NA,              "AltGr",           U_DF(U_SYM),       U_DF(U_MOUSE),     U_NA,              U_NU,              "Scroll Left",     "Scroll Down",     "Scroll Up",       "Scroll Right",    \
-U_NP,              U_NP,              U_NA,              U_NA,              U_HELD(U_NA),      "Right Button",    "Left Button",     "Middle Button",   U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              "Right Button",    "Right Button",    "Left Button",     "Middle Button",   U_NP,              U_NP
 
 
 #define MIRYOKU_ALTERNATIVES_MEDIA_INVERTEDT_FLIP \
 U_S("Hue  -", "RGB Hue  +"),U_S("Sat  -", "RGB Sat  +"),"Volume Up",       U_S("Value  -", "RGB Value  +"),U_S("Off", "RGB Toggle"),U_NA,              U_DF(U_BASE),      U_DF(U_EXTRA),     U_DF(U_TAP),       U_BOOT,            \
 U_S("Mode  -", "RGB Mode  +"),"Prev",            "Volume Down",     "Next",            U_S("Off", "EP Toggle"),U_NA,              "Shift",           "Ctrl",            "Alt",             "Meta",            \
 U_S("Clear", "BT  0 Select"),U_S("Clear", "BT  1 Select"),U_S("Clear", "BT  2 Select"),U_S("Clear", "BT  3 Select"),U_S("USB", "Out Toggle"),U_NA,              U_DF(U_MEDIA),     U_DF(U_FUN),       "AltGr",           U_NA,              \
-U_NP,              U_NP,              "Mute",            "Play Pause",      "Stop",            U_NA,              U_NA,              U_HELD(U_NA),      U_NP,              U_NP
+U_NP,              U_NP,              "Mute",            "Play Pause",      "Stop",            "Stop",            U_NA,              U_HELD(U_NA),      U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MEDIA_FLIP \
 U_S("Mode  -", "RGB Mode  +"),U_S("Hue  -", "RGB Hue  +"),U_S("Sat  -", "RGB Sat  +"),U_S("Value  -", "RGB Value  +"),U_S("Off", "RGB Toggle"),U_NA,              U_DF(U_BASE),      U_DF(U_EXTRA),     U_DF(U_TAP),       U_BOOT,            \
 "Prev",            "Volume Down",     "Volume Up",       "Next",            U_S("Off", "EP Toggle"),U_NA,              "Shift",           "Ctrl",            "Alt",             "Meta",            \
 U_S("Clear", "BT  0 Select"),U_S("Clear", "BT  1 Select"),U_S("Clear", "BT  2 Select"),U_S("Clear", "BT  3 Select"),U_S("USB", "Out Toggle"),U_NA,              U_DF(U_MEDIA),     U_DF(U_FUN),       "AltGr",           U_NA,              \
-U_NP,              U_NP,              "Mute",            "Play Pause",      "Stop",            U_NA,              U_NA,              U_HELD(U_NA),      U_NP,              U_NP
+U_NP,              U_NP,              "Mute",            "Play Pause",      "Stop",            "Stop",            U_NA,              U_HELD(U_NA),      U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MEDIA_INVERTEDT \
 U_BOOT,            U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              U_S("Off", "RGB Toggle"),U_S("Mode  -", "RGB Mode  +"),"Volume Up",       U_S("Hue  -", "RGB Hue  +"),U_S("Sat  -", "RGB Sat  +"),\
 "Meta",            "Alt",             "Ctrl",            "Shift",           U_NA,              U_S("Off", "EP Toggle"),"Prev",            "Volume Down",     "Next",            U_S("Value  -", "RGB Value  +"),\
 U_NA,              "AltGr",           U_DF(U_FUN),       U_DF(U_MEDIA),     U_NA,              U_S("USB", "Out Toggle"),U_S("Clear", "BT  0 Select"),U_S("Clear", "BT  1 Select"),U_S("Clear", "BT  2 Select"),U_S("Clear", "BT  3 Select"),\
-U_NP,              U_NP,              U_HELD(U_NA),      U_NA,              U_NA,              "Stop",            "Play Pause",      "Mute",            U_NP,              U_NP
+U_NP,              U_NP,              U_HELD(U_NA),      U_NA,              "Stop",            "Stop",            "Play Pause",      "Mute",            U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MEDIA_VI \
 U_BOOT,            U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              U_S("Mode  -", "RGB Mode  +"),U_S("Hue  -", "RGB Hue  +"),U_S("Sat  -", "RGB Sat  +"),U_S("Value  -", "RGB Value  +"),U_S("Off", "RGB Toggle"),\
 "Meta",            "Alt",             "Ctrl",            "Shift",           U_NA,              "Prev",            "Volume Down",     "Volume Up",       "Next",            U_S("Off", "EP Toggle"),\
 U_NA,              "AltGr",           U_DF(U_FUN),       U_DF(U_MEDIA),     U_NA,              U_S("Clear", "BT  0 Select"),U_S("Clear", "BT  1 Select"),U_S("Clear", "BT  2 Select"),U_S("Clear", "BT  3 Select"),U_S("USB", "Out Toggle"),\
-U_NP,              U_NP,              U_HELD(U_NA),      U_NA,              U_NA,              "Stop",            "Play Pause",      "Mute",            U_NP,              U_NP
+U_NP,              U_NP,              U_HELD(U_NA),      U_NA,              "Stop",            "Stop",            "Play Pause",      "Mute",            U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MEDIA \
 U_BOOT,            U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              U_S("Off", "RGB Toggle"),U_S("Mode  -", "RGB Mode  +"),U_S("Hue  -", "RGB Hue  +"),U_S("Sat  -", "RGB Sat  +"),U_S("Value  -", "RGB Value  +"),\
 "Meta",            "Alt",             "Ctrl",            "Shift",           U_NA,              U_S("Off", "EP Toggle"),"Prev",            "Volume Down",     "Volume Up",       "Next",            \
 U_NA,              "AltGr",           U_DF(U_FUN),       U_DF(U_MEDIA),     U_NA,              U_S("USB", "Out Toggle"),U_S("Clear", "BT  0 Select"),U_S("Clear", "BT  1 Select"),U_S("Clear", "BT  2 Select"),U_S("Clear", "BT  3 Select"),\
-U_NP,              U_NP,              U_HELD(U_NA),      U_NA,              U_NA,              "Stop",            "Play Pause",      "Mute",            U_NP,              U_NP
+U_NP,              U_NP,              U_HELD(U_NA),      U_NA,              "Stop",            "Stop",            "Play Pause",      "Mute",            U_NP,              U_NP
 
 
 #define MIRYOKU_ALTERNATIVES_NUM_FLIP \
 U_BOOT,            U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              U_S("{", "["),     U_S("&", "7"),     U_S("*", "8"),     U_S("S_LPRN", "9"),U_S("}", "]"),     \
 "Meta",            "Alt",             "Ctrl",            "Shift",           U_NA,              U_S("+", "="),     U_S("$", "4"),     U_S("%", "5"),     U_S("^", "6"),     U_S(":", ";"),     \
 U_NA,              "AltGr",           U_DF(U_NAV),       U_DF(U_NUM),       U_NA,              U_S("S_PIPE", "\\"),U_S("!", "1"),     U_S("@", "2"),     U_S("#", "3"),     U_S("~", "`"),     \
-U_NP,              U_NP,              U_NA,              U_HELD(U_NA),      U_NA,              U_S("_", "-"),     U_S("S_RPRN", "0"),U_S(">", "."),     U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_HELD(U_NA),      "-",               U_S("_", "-"),     U_S("S_RPRN", "0"),U_S(">", "."),     U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_NUM \
 U_S("{", "["),     U_S("&", "7"),     U_S("*", "8"),     U_S("S_LPRN", "9"),U_S("}", "]"),     U_NA,              U_DF(U_BASE),      U_DF(U_EXTRA),     U_DF(U_TAP),       U_BOOT,            \
 U_S(":", ";"),     U_S("$", "4"),     U_S("%", "5"),     U_S("^", "6"),     U_S("+", "="),     U_NA,              "Shift",           "Ctrl",            "Alt",             "Meta",            \
 U_S("~", "`"),     U_S("!", "1"),     U_S("@", "2"),     U_S("#", "3"),     U_S("S_PIPE", "\\"),U_NA,              U_DF(U_NUM),       U_DF(U_NAV),       "AltGr",           U_NA,              \
-U_NP,              U_NP,              U_S(">", "."),     U_S("S_RPRN", "0"),U_S("_", "-"),     U_NA,              U_HELD(U_NA),      U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              U_S(">", "."),     U_S("S_RPRN", "0"),U_S("_", "-"),     "-",               U_HELD(U_NA),      U_NA,              U_NP,              U_NP
 
 
 #define MIRYOKU_ALTERNATIVES_SYM_FLIP \
 U_BOOT,            U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              "{",               "&",               "*",               "S_LPRN",          "}",               \
 "Meta",            "Alt",             "Ctrl",            "Shift",           U_NA,              "+",               "$",               "%",               "^",               ":",               \
 U_NA,              "AltGr",           U_DF(U_MOUSE),     U_DF(U_SYM),       U_NA,              "S_PIPE",          "!",               "@",               "#",               "~",               \
-U_NP,              U_NP,              U_NA,              U_NA,              U_HELD(U_NA),      "_",               "S_LPRN",          "S_RPRN",          U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              "_",               "_",               "S_LPRN",          "S_RPRN",          U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_SYM \
 "{",               "&",               "*",               "S_LPRN",          "}",               U_NA,              U_DF(U_BASE),      U_DF(U_EXTRA),     U_DF(U_TAP),       U_BOOT,            \
 ":",               "$",               "%",               "^",               "+",               U_NA,              "Shift",           "Ctrl",            "Alt",             "Meta",            \
 "~",               "!",               "@",               "#",               "S_PIPE",          U_NA,              U_DF(U_SYM),       U_DF(U_MOUSE),     "AltGr",           U_NA,              \
-U_NP,              U_NP,              "S_LPRN",          "S_RPRN",          "_",               U_HELD(U_NA),      U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              "S_LPRN",          "S_RPRN",          "_",               "_",               U_NA,              U_NA,              U_NP,              U_NP
 
 
 #define MIRYOKU_ALTERNATIVES_FUN_FLIP \
 U_BOOT,            U_DF(U_TAP),       U_DF(U_EXTRA),     U_DF(U_BASE),      U_NA,              "PrtScn SysRq",    "F7",              "F8",              "F9",              "F12",             \
 "Meta",            "Alt",             "Ctrl",            "Shift",           U_NA,              "Scroll Lock",     "F4",              "F5",              "F6",              "F11",             \
 U_NA,              "AltGr",           U_DF(U_MEDIA),     U_DF(U_FUN),       U_NA,              "Pause Break",     "F1",              "F2",              "F3",              "F10",             \
-U_NP,              U_NP,              U_HELD(U_NA),      U_NA,              U_NA,              "Tab",             "Space",           "App",             U_NP,              U_NP
+U_NP,              U_NP,              U_HELD(U_NA),      U_NA,              "Tab",             "Tab",             "Space",           "App",             U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_FUN \
 "F12",             "F7",              "F8",              "F9",              "PrtScn SysRq",    U_NA,              U_DF(U_BASE),      U_DF(U_EXTRA),     U_DF(U_TAP),       U_BOOT,            \
 "F11",             "F4",              "F5",              "F6",              "Scroll Lock",     U_NA,              "Shift",           "Ctrl",            "Alt",             "Meta",            \
 "F10",             "F1",              "F2",              "F3",              "Pause Break",     U_NA,              U_DF(U_FUN),       U_DF(U_MEDIA),     "AltGr",           U_NA,              \
-U_NP,              U_NP,              "App",             "Space",           "Tab",             U_NA,              U_NA,              U_HELD(U_NA),      U_NP,              U_NP
+U_NP,              U_NP,              "App",             "Space",           "Tab",             "Tab",             U_NA,              U_HELD(U_NA),      U_NP,              U_NP
 
 
 #define MIRYOKU_ALTERNATIVES_BUTTON \

--- a/tangled/zmk/miryoku_layer_alternatives.h
+++ b/tangled/zmk/miryoku_layer_alternatives.h
@@ -252,132 +252,132 @@ U_NP,              U_NP,              &kp ESC,           &kp SPACE,         &kp 
 &kp PG_UP,         &kp HOME,          &kp UP,            &kp END,           &kp INS,           U_NA,              &u_to_U_BASE,      &u_to_U_EXTRA,     &u_to_U_TAP,       U_BOOT,            \
 &kp PG_DN,         &kp LEFT,          &kp DOWN,          &kp RIGHT,         &u_caps_word,      U_NA,              &kp LSHFT,         &kp LCTRL,         &kp LALT,          &kp LGUI,          \
 U_UND,             U_CUT,             U_CPY,             U_PST,             U_RDO,             U_NA,              &u_to_U_NAV,       &u_to_U_NUM,       &kp RALT,          U_NA,              \
-U_NP,              U_NP,              &kp DEL,           &kp BSPC,          &kp RET,           U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              &kp DEL,           &kp BSPC,          &kp RET,           &kp RET,           U_NA,              U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_NAV_FLIP \
 &kp HOME,          &kp PG_DN,         &kp PG_UP,         &kp END,           &kp INS,           U_NA,              &u_to_U_BASE,      &u_to_U_EXTRA,     &u_to_U_TAP,       U_BOOT,            \
 &kp LEFT,          &kp DOWN,          &kp UP,            &kp RIGHT,         &u_caps_word,      U_NA,              &kp LSHFT,         &kp LCTRL,         &kp LALT,          &kp LGUI,          \
 U_UND,             U_CUT,             U_CPY,             U_PST,             U_RDO,             U_NA,              &u_to_U_NAV,       &u_to_U_NUM,       &kp RALT,          U_NA,              \
-U_NP,              U_NP,              &kp DEL,           &kp BSPC,          &kp RET,           U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              &kp DEL,           &kp BSPC,          &kp RET,           &kp RET,           U_NA,              U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_NAV_INVERTEDT \
 U_BOOT,            &u_to_U_TAP,       &u_to_U_EXTRA,     &u_to_U_BASE,      U_NA,              &kp INS,           &kp HOME,          &kp UP,            &kp END,           &kp PG_UP,         \
 &kp LGUI,          &kp LALT,          &kp LCTRL,         &kp LSHFT,         U_NA,              &u_caps_word,      &kp LEFT,          &kp DOWN,          &kp RIGHT,         &kp PG_DN,         \
 U_NA,              &kp RALT,          &u_to_U_NUM,       &u_to_U_NAV,       U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              &kp RET,           &kp BSPC,          &kp DEL,           U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              &kp RET,           &kp RET,           &kp BSPC,          &kp DEL,           U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_NAV_VI \
 U_BOOT,            &u_to_U_TAP,       &u_to_U_EXTRA,     &u_to_U_BASE,      U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
 &kp LGUI,          &kp LALT,          &kp LCTRL,         &kp LSHFT,         U_NA,              &kp LEFT,          &kp DOWN,          &kp UP,            &kp RIGHT,         &u_caps_word,      \
 U_NA,              &kp RALT,          &u_to_U_NUM,       &u_to_U_NAV,       U_NA,              &kp HOME,          &kp PG_DN,         &kp PG_UP,         &kp END,           &kp INS,           \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              &kp RET,           &kp BSPC,          &kp DEL,           U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              &kp RET,           &kp RET,           &kp BSPC,          &kp DEL,           U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_NAV \
 U_BOOT,            &u_to_U_TAP,       &u_to_U_EXTRA,     &u_to_U_BASE,      U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
 &kp LGUI,          &kp LALT,          &kp LCTRL,         &kp LSHFT,         U_NA,              &u_caps_word,      &kp LEFT,          &kp DOWN,          &kp UP,            &kp RIGHT,         \
 U_NA,              &kp RALT,          &u_to_U_NUM,       &u_to_U_NAV,       U_NA,              &kp INS,           &kp HOME,          &kp PG_DN,         &kp PG_UP,         &kp END,           \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              &kp RET,           &kp BSPC,          &kp DEL,           U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              &kp RET,           &kp RET,           &kp BSPC,          &kp DEL,           U_NP,              U_NP
 
 
 #define MIRYOKU_ALTERNATIVES_MOUSE_INVERTEDT_FLIP \
 U_WH_U,            U_WH_L,            U_MS_U,            U_WH_R,            U_NU,              U_NA,              &u_to_U_BASE,      &u_to_U_EXTRA,     &u_to_U_TAP,       U_BOOT,            \
 U_WH_D,            U_MS_L,            U_MS_D,            U_MS_R,            U_NU,              U_NA,              &kp LSHFT,         &kp LCTRL,         &kp LALT,          &kp LGUI,          \
 U_UND,             U_CUT,             U_CPY,             U_PST,             U_RDO,             U_NA,              &u_to_U_MOUSE,     &u_to_U_SYM,       &kp RALT,          U_NA,              \
-U_NP,              U_NP,              U_BTN3,            U_BTN1,            U_BTN2,            U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              U_BTN3,            U_BTN1,            U_BTN2,            U_BTN2,            U_NA,              U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MOUSE_FLIP \
 U_WH_L,            U_WH_D,            U_WH_U,            U_WH_R,            U_NU,              U_NA,              &u_to_U_BASE,      &u_to_U_EXTRA,     &u_to_U_TAP,       U_BOOT,            \
 U_MS_L,            U_MS_D,            U_MS_U,            U_MS_R,            U_NU,              U_NA,              &kp LSHFT,         &kp LCTRL,         &kp LALT,          &kp LGUI,          \
 U_UND,             U_CUT,             U_CPY,             U_PST,             U_RDO,             U_NA,              &u_to_U_MOUSE,     &u_to_U_SYM,       &kp RALT,          U_NA,              \
-U_NP,              U_NP,              U_BTN3,            U_BTN1,            U_BTN2,            U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              U_BTN3,            U_BTN1,            U_BTN2,            U_BTN2,            U_NA,              U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MOUSE_INVERTEDT \
 U_BOOT,            &u_to_U_TAP,       &u_to_U_EXTRA,     &u_to_U_BASE,      U_NA,              U_NU,              U_WH_L,            U_MS_U,            U_WH_R,            U_WH_U,            \
 &kp LGUI,          &kp LALT,          &kp LCTRL,         &kp LSHFT,         U_NA,              U_NU,              U_MS_L,            U_MS_D,            U_MS_R,            U_WH_D,            \
 U_NA,              &kp RALT,          &u_to_U_SYM,       &u_to_U_MOUSE,     U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              U_BTN2,            U_BTN1,            U_BTN3,            U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              U_BTN2,            U_BTN2,            U_BTN1,            U_BTN3,            U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MOUSE_VI \
 U_BOOT,            &u_to_U_TAP,       &u_to_U_EXTRA,     &u_to_U_BASE,      U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
 &kp LGUI,          &kp LALT,          &kp LCTRL,         &kp LSHFT,         U_NA,              U_MS_L,            U_MS_D,            U_MS_U,            U_MS_R,            U_NU,              \
 U_NA,              &kp RALT,          &u_to_U_SYM,       &u_to_U_MOUSE,     U_NA,              U_WH_L,            U_WH_D,            U_WH_U,            U_WH_R,            U_NU,              \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              U_BTN2,            U_BTN1,            U_BTN3,            U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              U_BTN2,            U_BTN2,            U_BTN1,            U_BTN3,            U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MOUSE \
 U_BOOT,            &u_to_U_TAP,       &u_to_U_EXTRA,     &u_to_U_BASE,      U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
 &kp LGUI,          &kp LALT,          &kp LCTRL,         &kp LSHFT,         U_NA,              U_NU,              U_MS_L,            U_MS_D,            U_MS_U,            U_MS_R,            \
 U_NA,              &kp RALT,          &u_to_U_SYM,       &u_to_U_MOUSE,     U_NA,              U_NU,              U_WH_L,            U_WH_D,            U_WH_U,            U_WH_R,            \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              U_BTN2,            U_BTN1,            U_BTN3,            U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              U_BTN2,            U_BTN2,            U_BTN1,            U_BTN3,            U_NP,              U_NP
 
 
 #define MIRYOKU_ALTERNATIVES_MEDIA_INVERTEDT_FLIP \
 U_RGB_HUI,         U_RGB_SAI,         &kp C_VOL_UP,      U_RGB_BRI,         U_RGB_TOG,         U_NA,              &u_to_U_BASE,      &u_to_U_EXTRA,     &u_to_U_TAP,       U_BOOT,            \
 U_RGB_EFF,         &kp C_PREV,        &kp C_VOL_DN,      &kp C_NEXT,        U_EP_TOG,          U_NA,              &kp LSHFT,         &kp LCTRL,         &kp LALT,          &kp LGUI,          \
 &u_bt_sel_0,       &u_bt_sel_1,       &u_bt_sel_2,       &u_bt_sel_3,       &u_out_tog,        U_NA,              &u_to_U_MEDIA,     &u_to_U_FUN,       &kp RALT,          U_NA,              \
-U_NP,              U_NP,              &kp C_MUTE,        &kp C_PP,          &kp C_STOP,        U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              &kp C_MUTE,        &kp C_PP,          &kp C_STOP,        &kp C_STOP,        U_NA,              U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MEDIA_FLIP \
 U_RGB_EFF,         U_RGB_HUI,         U_RGB_SAI,         U_RGB_BRI,         U_RGB_TOG,         U_NA,              &u_to_U_BASE,      &u_to_U_EXTRA,     &u_to_U_TAP,       U_BOOT,            \
 &kp C_PREV,        &kp C_VOL_DN,      &kp C_VOL_UP,      &kp C_NEXT,        U_EP_TOG,          U_NA,              &kp LSHFT,         &kp LCTRL,         &kp LALT,          &kp LGUI,          \
 &u_bt_sel_0,       &u_bt_sel_1,       &u_bt_sel_2,       &u_bt_sel_3,       &u_out_tog,        U_NA,              &u_to_U_MEDIA,     &u_to_U_FUN,       &kp RALT,          U_NA,              \
-U_NP,              U_NP,              &kp C_MUTE,        &kp C_PP,          &kp C_STOP,        U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              &kp C_MUTE,        &kp C_PP,          &kp C_STOP,        &kp C_STOP,        U_NA,              U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MEDIA_INVERTEDT \
 U_BOOT,            &u_to_U_TAP,       &u_to_U_EXTRA,     &u_to_U_BASE,      U_NA,              U_RGB_TOG,         U_RGB_EFF,         &kp C_VOL_UP,      U_RGB_HUI,         U_RGB_SAI,         \
 &kp LGUI,          &kp LALT,          &kp LCTRL,         &kp LSHFT,         U_NA,              U_EP_TOG,          &kp C_PREV,        &kp C_VOL_DN,      &kp C_NEXT,        U_RGB_BRI,         \
 U_NA,              &kp RALT,          &u_to_U_FUN,       &u_to_U_MEDIA,     U_NA,              &u_out_tog,        &u_bt_sel_0,       &u_bt_sel_1,       &u_bt_sel_2,       &u_bt_sel_3,       \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              &kp C_STOP,        &kp C_PP,          &kp C_MUTE,        U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              &kp C_STOP,        &kp C_STOP,        &kp C_PP,          &kp C_MUTE,        U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MEDIA_VI \
 U_BOOT,            &u_to_U_TAP,       &u_to_U_EXTRA,     &u_to_U_BASE,      U_NA,              U_RGB_EFF,         U_RGB_HUI,         U_RGB_SAI,         U_RGB_BRI,         U_RGB_TOG,         \
 &kp LGUI,          &kp LALT,          &kp LCTRL,         &kp LSHFT,         U_NA,              &kp C_PREV,        &kp C_VOL_DN,      &kp C_VOL_UP,      &kp C_NEXT,        U_EP_TOG,          \
 U_NA,              &kp RALT,          &u_to_U_FUN,       &u_to_U_MEDIA,     U_NA,              &u_bt_sel_0,       &u_bt_sel_1,       &u_bt_sel_2,       &u_bt_sel_3,       &u_out_tog,        \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              &kp C_STOP,        &kp C_PP,          &kp C_MUTE,        U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              &kp C_STOP,        &kp C_STOP,        &kp C_PP,          &kp C_MUTE,        U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MEDIA \
 U_BOOT,            &u_to_U_TAP,       &u_to_U_EXTRA,     &u_to_U_BASE,      U_NA,              U_RGB_TOG,         U_RGB_EFF,         U_RGB_HUI,         U_RGB_SAI,         U_RGB_BRI,         \
 &kp LGUI,          &kp LALT,          &kp LCTRL,         &kp LSHFT,         U_NA,              U_EP_TOG,          &kp C_PREV,        &kp C_VOL_DN,      &kp C_VOL_UP,      &kp C_NEXT,        \
 U_NA,              &kp RALT,          &u_to_U_FUN,       &u_to_U_MEDIA,     U_NA,              &u_out_tog,        &u_bt_sel_0,       &u_bt_sel_1,       &u_bt_sel_2,       &u_bt_sel_3,       \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              &kp C_STOP,        &kp C_PP,          &kp C_MUTE,        U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              &kp C_STOP,        &kp C_STOP,        &kp C_PP,          &kp C_MUTE,        U_NP,              U_NP
 
 
 #define MIRYOKU_ALTERNATIVES_NUM_FLIP \
 U_BOOT,            &u_to_U_TAP,       &u_to_U_EXTRA,     &u_to_U_BASE,      U_NA,              &kp LBKT,          &kp N7,            &kp N8,            &kp N9,            &kp RBKT,          \
 &kp LGUI,          &kp LALT,          &kp LCTRL,         &kp LSHFT,         U_NA,              &kp EQUAL,         &kp N4,            &kp N5,            &kp N6,            &kp SEMI,          \
 U_NA,              &kp RALT,          &u_to_U_NAV,       &u_to_U_NUM,       U_NA,              &kp BSLH,          &kp N1,            &kp N2,            &kp N3,            &kp GRAVE,         \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              &kp MINUS,         &kp N0,            &kp DOT,           U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              &kp MINUS,         &kp MINUS,         &kp N0,            &kp DOT,           U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_NUM \
 &kp LBKT,          &kp N7,            &kp N8,            &kp N9,            &kp RBKT,          U_NA,              &u_to_U_BASE,      &u_to_U_EXTRA,     &u_to_U_TAP,       U_BOOT,            \
 &kp SEMI,          &kp N4,            &kp N5,            &kp N6,            &kp EQUAL,         U_NA,              &kp LSHFT,         &kp LCTRL,         &kp LALT,          &kp LGUI,          \
 &kp GRAVE,         &kp N1,            &kp N2,            &kp N3,            &kp BSLH,          U_NA,              &u_to_U_NUM,       &u_to_U_NAV,       &kp RALT,          U_NA,              \
-U_NP,              U_NP,              &kp DOT,           &kp N0,            &kp MINUS,         U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              &kp DOT,           &kp N0,            &kp MINUS,         &kp MINUS,         U_NA,              U_NA,              U_NP,              U_NP
 
 
 #define MIRYOKU_ALTERNATIVES_SYM_FLIP \
 U_BOOT,            &u_to_U_TAP,       &u_to_U_EXTRA,     &u_to_U_BASE,      U_NA,              &kp LBRC,          &kp AMPS,          &kp ASTRK,         &kp LPAR,          &kp RBRC,          \
 &kp LGUI,          &kp LALT,          &kp LCTRL,         &kp LSHFT,         U_NA,              &kp PLUS,          &kp DLLR,          &kp PRCNT,         &kp CARET,         &kp COLON,         \
 U_NA,              &kp RALT,          &u_to_U_MOUSE,     &u_to_U_SYM,       U_NA,              &kp PIPE,          &kp EXCL,          &kp AT,            &kp HASH,          &kp TILDE,         \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              &kp UNDER,         &kp LPAR,          &kp RPAR,          U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              &kp UNDER,         &kp UNDER,         &kp LPAR,          &kp RPAR,          U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_SYM \
 &kp LBRC,          &kp AMPS,          &kp ASTRK,         &kp LPAR,          &kp RBRC,          U_NA,              &u_to_U_BASE,      &u_to_U_EXTRA,     &u_to_U_TAP,       U_BOOT,            \
 &kp COLON,         &kp DLLR,          &kp PRCNT,         &kp CARET,         &kp PLUS,          U_NA,              &kp LSHFT,         &kp LCTRL,         &kp LALT,          &kp LGUI,          \
 &kp TILDE,         &kp EXCL,          &kp AT,            &kp HASH,          &kp PIPE,          U_NA,              &u_to_U_SYM,       &u_to_U_MOUSE,     &kp RALT,          U_NA,              \
-U_NP,              U_NP,              &kp LPAR,          &kp RPAR,          &kp UNDER,         U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              &kp LPAR,          &kp RPAR,          &kp UNDER,         &kp UNDER,         U_NA,              U_NA,              U_NP,              U_NP
 
 
 #define MIRYOKU_ALTERNATIVES_FUN_FLIP \
 U_BOOT,            &u_to_U_TAP,       &u_to_U_EXTRA,     &u_to_U_BASE,      U_NA,              &kp PSCRN,         &kp F7,            &kp F8,            &kp F9,            &kp F12,           \
 &kp LGUI,          &kp LALT,          &kp LCTRL,         &kp LSHFT,         U_NA,              &kp SLCK,          &kp F4,            &kp F5,            &kp F6,            &kp F11,           \
 U_NA,              &kp RALT,          &u_to_U_MEDIA,     &u_to_U_FUN,       U_NA,              &kp PAUSE_BREAK,   &kp F1,            &kp F2,            &kp F3,            &kp F10,           \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              &kp TAB,           &kp SPACE,         &kp K_APP,         U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              &kp TAB,           &kp TAB,           &kp SPACE,         &kp K_APP,         U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_FUN \
 &kp F12,           &kp F7,            &kp F8,            &kp F9,            &kp PSCRN,         U_NA,              &u_to_U_BASE,      &u_to_U_EXTRA,     &u_to_U_TAP,       U_BOOT,            \
 &kp F11,           &kp F4,            &kp F5,            &kp F6,            &kp SLCK,          U_NA,              &kp LSHFT,         &kp LCTRL,         &kp LALT,          &kp LGUI,          \
 &kp F10,           &kp F1,            &kp F2,            &kp F3,            &kp PAUSE_BREAK,   U_NA,              &u_to_U_FUN,       &u_to_U_MEDIA,     &kp RALT,          U_NA,              \
-U_NP,              U_NP,              &kp K_APP,         &kp SPACE,         &kp TAB,           U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              &kp K_APP,         &kp SPACE,         &kp TAB,           &kp TAB,           U_NA,              U_NA,              U_NP,              U_NP
 
 
 #define MIRYOKU_ALTERNATIVES_BUTTON \


### PR DESCRIPTION
What do you think about duplicating the half-layer inner thumb to both inner thumbs, replacing `U_NA` on the hold side, for boards with a common, MIT thumb key? e.g. on the num layer, put <kbd>MINUS</kbd> on the right (and left) inner thumb.

On the ZMK REVIUNG41/39 that puts all the half-layer inner thumbs on the MIT thumb --- not just the right ones and nothing on the left half-layers.

On boards with independent inner thumbs the hold side isn't available because that thumb is holding the layer tap, so the keymap position isn't used. But an MIT thumb key it's reachable equally by either hand.

I added the following line to `table-layer-half` to try it out and confirm that it worked (with ZMK):
```py
hold_table[-1][length - 1] = hold_table[-1][length] = convert_symbol(half_table[-1][-1 if mode == 'l' else 0])
```

:point_up: Copies the `half_table` inner thumb to both `hold_table` inner thumbs.