### PR TITLE
Upgrade to actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: 'Main'
+name: "Main"
 on:
   workflow_call:
     inputs:
@@ -59,7 +59,7 @@ jobs:
           git diff --exit-code
       - name: Archive Artifacts
         if: ${{ matrix.mode == 'build' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: 'miryoku_babel'
+          name: "miryoku_babel"
           path: tangled


### PR DESCRIPTION
`actions/upload-artifact@v3` has been deprecated and unavailable since Jan 30, 2025 according to this [page](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/). This PR updates it to `actions/upload-artifact@v4` 