### PR TITLE
Update QMK codes

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -648,9 +648,9 @@ Source keycode to implementation equivalent (source, QMK, ZMK, KMonad, SVG, KMK)
 | BT_SEL_2    |                  | &u_bt_sel_2   |               | BT  2 Select  |               |
 | BT_SEL_3    |                  | &u_bt_sel_3   |               | BT  3 Select  |               |
 | BT_SEL_4    |                  | &u_bt_sel_4   |               | BT  4 Select  |               |
-| BTN1        | BTN1             | U_BTN1        | #(kp/ kp5)    | Left Button   | MB_LMB        |
-| BTN2        | BTN2             | U_BTN2        | #(kp- kp5)    | Right Button  | MB_RMB        |
-| BTN3        | BTN3             | U_BTN3        | #(kp* kp5)    | Middle Button | MB_MMB        |
+| BTN1        | MS_BTN1          | U_BTN1        | #(kp/ kp5)    | Left Button   | MB_LMB        |
+| BTN2        | MS_BTN2          | U_BTN2        | #(kp- kp5)    | Right Button  | MB_RMB        |
+| BTN3        | MS_BTN3          | U_BTN3        | #(kp* kp5)    | Middle Button | MB_MMB        |
 | CAPS        | CAPS             | CAPS          | caps          | Caps Lock     | CAPS          |
 | CIRC        | CIRC             | CARET         | ^             | ^             | CIRC          |
 | COLN        | COLN             | COLON         | :             | :             | COLN          |
@@ -701,10 +701,10 @@ Source keycode to implementation equivalent (source, QMK, ZMK, KMonad, SVG, KMK)
 | MNXT        | MNXT             | C_NEXT        | nextsong      | Next          | MNXT          |
 | MPLY        | MPLY             | C_PP          | playpause     | Play Pause    | MPLY          |
 | MPRV        | MPRV             | C_PREV        | previoussong  | Prev          | MPRV          |
-| MS_D        | MS_D             | U_MS_D        | kp2           | Mouse Down    | MS_DN         |
-| MS_L        | MS_L             | U_MS_L        | kp4           | Mouse Left    | MS_LT         |
-| MS_R        | MS_R             | U_MS_R        | kp6           | Mouse Right   | MS_RT         |
-| MS_U        | MS_U             | U_MS_U        | kp8           | Mouse Up      | MS_UP         |
+| MS_D        | MS_DOWN          | U_MS_D        | kp2           | Mouse Down    | MS_DN         |
+| MS_L        | MS_LEFT          | U_MS_L        | kp4           | Mouse Left    | MS_LT         |
+| MS_R        | MS_RGHT          | U_MS_R        | kp6           | Mouse Right   | MS_RT         |
+| MS_U        | MS_UP            | U_MS_U        | kp8           | Mouse Up      | MS_UP         |
 | MSTP        | MSTP             | C_STOP        | stopcd        | Stop          | MSTP          |
 | MUTE        | MUTE             | C_MUTE        | mute          | Mute          | MUTE          |
 | NO          | NO               | &none         | XX            |               | NO            |
@@ -723,16 +723,16 @@ Source keycode to implementation equivalent (source, QMK, ZMK, KMonad, SVG, KMK)
 | RBRC        | RBRC             | RBKT          | ]             | ]             | RBRC          |
 | RCBR        | RCBR             | RBRC          | }             | }             | RCBR          |
 | RESET       | QK_RBT           | &reset        |               | Reset         | RESET         |
-| RGB_HUD     | RGB_HUD          |               |               | RGB Hue  -    | U_RGB_HUD     |
-| RGB_HUI     | RGB_HUI          | U_RGB_HUI     |               | RGB Hue  +    | U_RGB_HUI     |
-| RGB_MOD     | RGB_MOD          | U_RGB_EFF     |               | RGB Mode  +   | U_RGB_MOD     |
-| RGB_RMOD    | RGB_RMOD         |               |               | RGB Mode  -   | U_RGB_RMOD    |
+| RGB_HUD     | UG_HUED          |               |               | RGB Hue  -    | U_RGB_HUD     |
+| RGB_HUI     | UG_HUEU          | U_RGB_HUI     |               | RGB Hue  +    | U_RGB_HUI     |
+| RGB_MOD     | UG_NEXT          | U_RGB_EFF     |               | RGB Mode  +   | U_RGB_MOD     |
+| RGB_RMOD    | UG_PREV          |               |               | RGB Mode  -   | U_RGB_RMOD    |
 | RGB_OFF     |                  |               |               | RGB Off       | U_RGB_OFF     |
-| RGB_SAD     | RGB_SAD          |               |               | RGB Sat  -    | U_RGB_SAD     |
-| RGB_SAI     | RGB_SAI          | U_RGB_SAI     |               | RGB Sat  +    | U_RGB_SAI     |
-| RGB_TOG     | RGB_TOG          | U_RGB_TOG     |               | RGB Toggle    | U_RGB_TOG     |
-| RGB_VAD     | RGB_VAD          |               |               | RGB Value  -  | U_RGB_VAD     |
-| RGB_VAI     | RGB_VAI          | U_RGB_BRI     |               | RGB Value  +  | U_RGB_VAI     |
+| RGB_SAD     | UG_SATD          |               |               | RGB Sat  -    | U_RGB_SAD     |
+| RGB_SAI     | UG_SATU          | U_RGB_SAI     |               | RGB Sat  +    | U_RGB_SAI     |
+| RGB_TOG     | UG_TOGG          | U_RGB_TOG     |               | RGB Toggle    | U_RGB_TOG     |
+| RGB_VAD     | UG_VALD          |               |               | RGB Value  -  | U_RGB_VAD     |
+| RGB_VAI     | UG_VALU          | U_RGB_BRI     |               | RGB Value  +  | U_RGB_VAI     |
 | RGHT        | RGHT             | RIGHT         | right         | Right         | RGHT          |
 | RPRN        | RPRN             | RPAR          | U_RPRN        | S_RPRN        | RPRN          |
 | SCLN        | SCLN             | SEMI          | ;             | ;             | SCLN          |
@@ -746,10 +746,10 @@ Source keycode to implementation equivalent (source, QMK, ZMK, KMonad, SVG, KMK)
 | UP          | UP               | UP            | up            | Up            | UP            |
 | VOLD        | VOLD             | C_VOL_DN      | vold          | Volume Down   | VOLD          |
 | VOLU        | VOLU             | C_VOL_UP      | volu          | Volume Up     | VOLU          |
-| WH_D        | WH_D             | U_WH_D        |               | Scroll Down   | MW_DN         |
-| WH_L        | WH_L             | U_WH_L        |               | Scroll Left   |               |
-| WH_R        | WH_R             | U_WH_R        |               | Scroll Right  |               |
-| WH_U        | WH_U             | U_WH_U        |               | Scroll Up     | MW_UP         |
+| WH_D        | MS_WHLD          | U_WH_D        |               | Scroll Down   | MW_DN         |
+| WH_L        | MS_WHLL          | U_WH_L        |               | Scroll Left   |               |
+| WH_R        | MS_WHLR          | U_WH_R        |               | Scroll Right  |               |
+| WH_U        | MS_WHLU          | U_WH_U        |               | Scroll Up     | MW_UP         |
 
 
 **** table-layer-init
@@ -1386,7 +1386,7 @@ Keycodes that match any of these prefixes will not have ~KC_~ automatically
 prepended.
 
 #+NAME: nonkc
-| U_ | RGB_ | OU_  | QK_ | S( | C( | SCMD( | LCMD( | TD( | CW_TOGG |
+| MS_ | U_ | UG_ | RGB_ | OU_  | QK_ | S( | C( | SCMD( | LCMD( | TD( | CW_TOGG |
 
 
 **** license-qmk
@@ -2642,6 +2642,6 @@ Keycodes that match any of these prefixes will not have ~KC.~ automatically prep
 #endif
 #+END_SRC
 
-** 
+**
 
 [[https://github.com/manna-harbour][https://raw.githubusercontent.com/manna-harbour/miryoku/master/data/logos/manna-harbour-boa-32.png]]

--- a/tangled/qmk/miryoku_layer_alternatives.h
+++ b/tangled/qmk/miryoku_layer_alternatives.h
@@ -282,62 +282,62 @@ U_NP,              U_NP,              U_NA,              U_NA,              U_NA
 
 
 #define MIRYOKU_ALTERNATIVES_MOUSE_INVERTEDT_FLIP \
-KC_WH_U,           KC_WH_L,           KC_MS_U,           KC_WH_R,           U_NU,              U_NA,              TD(U_TD_U_BASE),   TD(U_TD_U_EXTRA),  TD(U_TD_U_TAP),    TD(U_TD_BOOT),     \
-KC_WH_D,           KC_MS_L,           KC_MS_D,           KC_MS_R,           U_NU,              U_NA,              KC_LSFT,           KC_LCTL,           KC_LALT,           KC_LGUI,           \
+MS_WHLU,           MS_WHLL,           MS_UP,             MS_WHLR,           U_NU,              U_NA,              TD(U_TD_U_BASE),   TD(U_TD_U_EXTRA),  TD(U_TD_U_TAP),    TD(U_TD_BOOT),     \
+MS_WHLD,           MS_LEFT,           MS_DOWN,           MS_RGHT,           U_NU,              U_NA,              KC_LSFT,           KC_LCTL,           KC_LALT,           KC_LGUI,           \
 U_UND,             U_CUT,             U_CPY,             U_PST,             U_RDO,             U_NA,              TD(U_TD_U_MOUSE),  TD(U_TD_U_SYM),    KC_ALGR,           U_NA,              \
-U_NP,              U_NP,              KC_BTN3,           KC_BTN1,           KC_BTN2,           U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              MS_BTN3,           MS_BTN1,           MS_BTN2,           U_NA,              U_NA,              U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MOUSE_FLIP \
-KC_WH_L,           KC_WH_D,           KC_WH_U,           KC_WH_R,           U_NU,              U_NA,              TD(U_TD_U_BASE),   TD(U_TD_U_EXTRA),  TD(U_TD_U_TAP),    TD(U_TD_BOOT),     \
-KC_MS_L,           KC_MS_D,           KC_MS_U,           KC_MS_R,           U_NU,              U_NA,              KC_LSFT,           KC_LCTL,           KC_LALT,           KC_LGUI,           \
+MS_WHLL,           MS_WHLD,           MS_WHLU,           MS_WHLR,           U_NU,              U_NA,              TD(U_TD_U_BASE),   TD(U_TD_U_EXTRA),  TD(U_TD_U_TAP),    TD(U_TD_BOOT),     \
+MS_LEFT,           MS_DOWN,           MS_UP,             MS_RGHT,           U_NU,              U_NA,              KC_LSFT,           KC_LCTL,           KC_LALT,           KC_LGUI,           \
 U_UND,             U_CUT,             U_CPY,             U_PST,             U_RDO,             U_NA,              TD(U_TD_U_MOUSE),  TD(U_TD_U_SYM),    KC_ALGR,           U_NA,              \
-U_NP,              U_NP,              KC_BTN3,           KC_BTN1,           KC_BTN2,           U_NA,              U_NA,              U_NA,              U_NP,              U_NP
+U_NP,              U_NP,              MS_BTN3,           MS_BTN1,           MS_BTN2,           U_NA,              U_NA,              U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MOUSE_INVERTEDT \
-TD(U_TD_BOOT),     TD(U_TD_U_TAP),    TD(U_TD_U_EXTRA),  TD(U_TD_U_BASE),   U_NA,              U_NU,              KC_WH_L,           KC_MS_U,           KC_WH_R,           KC_WH_U,           \
-KC_LGUI,           KC_LALT,           KC_LCTL,           KC_LSFT,           U_NA,              U_NU,              KC_MS_L,           KC_MS_D,           KC_MS_R,           KC_WH_D,           \
+TD(U_TD_BOOT),     TD(U_TD_U_TAP),    TD(U_TD_U_EXTRA),  TD(U_TD_U_BASE),   U_NA,              U_NU,              MS_WHLL,           MS_UP,             MS_WHLR,           MS_WHLU,           \
+KC_LGUI,           KC_LALT,           KC_LCTL,           KC_LSFT,           U_NA,              U_NU,              MS_LEFT,           MS_DOWN,           MS_RGHT,           MS_WHLD,           \
 U_NA,              KC_ALGR,           TD(U_TD_U_SYM),    TD(U_TD_U_MOUSE),  U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              KC_BTN2,           KC_BTN1,           KC_BTN3,           U_NP,              U_NP
+U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              MS_BTN2,           MS_BTN1,           MS_BTN3,           U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MOUSE_VI \
 TD(U_TD_BOOT),     TD(U_TD_U_TAP),    TD(U_TD_U_EXTRA),  TD(U_TD_U_BASE),   U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
-KC_LGUI,           KC_LALT,           KC_LCTL,           KC_LSFT,           U_NA,              KC_MS_L,           KC_MS_D,           KC_MS_U,           KC_MS_R,           U_NU,              \
-U_NA,              KC_ALGR,           TD(U_TD_U_SYM),    TD(U_TD_U_MOUSE),  U_NA,              KC_WH_L,           KC_WH_D,           KC_WH_U,           KC_WH_R,           U_NU,              \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              KC_BTN2,           KC_BTN1,           KC_BTN3,           U_NP,              U_NP
+KC_LGUI,           KC_LALT,           KC_LCTL,           KC_LSFT,           U_NA,              MS_LEFT,           MS_DOWN,           MS_UP,             MS_RGHT,           U_NU,              \
+U_NA,              KC_ALGR,           TD(U_TD_U_SYM),    TD(U_TD_U_MOUSE),  U_NA,              MS_WHLL,           MS_WHLD,           MS_WHLU,           MS_WHLR,           U_NU,              \
+U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              MS_BTN2,           MS_BTN1,           MS_BTN3,           U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MOUSE \
 TD(U_TD_BOOT),     TD(U_TD_U_TAP),    TD(U_TD_U_EXTRA),  TD(U_TD_U_BASE),   U_NA,              U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
-KC_LGUI,           KC_LALT,           KC_LCTL,           KC_LSFT,           U_NA,              U_NU,              KC_MS_L,           KC_MS_D,           KC_MS_U,           KC_MS_R,           \
-U_NA,              KC_ALGR,           TD(U_TD_U_SYM),    TD(U_TD_U_MOUSE),  U_NA,              U_NU,              KC_WH_L,           KC_WH_D,           KC_WH_U,           KC_WH_R,           \
-U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              KC_BTN2,           KC_BTN1,           KC_BTN3,           U_NP,              U_NP
+KC_LGUI,           KC_LALT,           KC_LCTL,           KC_LSFT,           U_NA,              U_NU,              MS_LEFT,           MS_DOWN,           MS_UP,             MS_RGHT,           \
+U_NA,              KC_ALGR,           TD(U_TD_U_SYM),    TD(U_TD_U_MOUSE),  U_NA,              U_NU,              MS_WHLL,           MS_WHLD,           MS_WHLU,           MS_WHLR,           \
+U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              MS_BTN2,           MS_BTN1,           MS_BTN3,           U_NP,              U_NP
 
 
 #define MIRYOKU_ALTERNATIVES_MEDIA_INVERTEDT_FLIP \
-RGB_HUI,           RGB_SAI,           KC_VOLU,           RGB_VAI,           RGB_TOG,           U_NA,              TD(U_TD_U_BASE),   TD(U_TD_U_EXTRA),  TD(U_TD_U_TAP),    TD(U_TD_BOOT),     \
-RGB_MOD,           KC_MPRV,           KC_VOLD,           KC_MNXT,           U_NU,              U_NA,              KC_LSFT,           KC_LCTL,           KC_LALT,           KC_LGUI,           \
+UG_HUEU,           UG_SATU,           KC_VOLU,           UG_VALU,           UG_TOGG,           U_NA,              TD(U_TD_U_BASE),   TD(U_TD_U_EXTRA),  TD(U_TD_U_TAP),    TD(U_TD_BOOT),     \
+UG_NEXT,           KC_MPRV,           KC_VOLD,           KC_MNXT,           U_NU,              U_NA,              KC_LSFT,           KC_LCTL,           KC_LALT,           KC_LGUI,           \
 U_NU,              U_NU,              U_NU,              U_NU,              OU_AUTO,           U_NA,              TD(U_TD_U_MEDIA),  TD(U_TD_U_FUN),    KC_ALGR,           U_NA,              \
 U_NP,              U_NP,              KC_MUTE,           KC_MPLY,           KC_MSTP,           U_NA,              U_NA,              U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MEDIA_FLIP \
-RGB_MOD,           RGB_HUI,           RGB_SAI,           RGB_VAI,           RGB_TOG,           U_NA,              TD(U_TD_U_BASE),   TD(U_TD_U_EXTRA),  TD(U_TD_U_TAP),    TD(U_TD_BOOT),     \
+UG_NEXT,           UG_HUEU,           UG_SATU,           UG_VALU,           UG_TOGG,           U_NA,              TD(U_TD_U_BASE),   TD(U_TD_U_EXTRA),  TD(U_TD_U_TAP),    TD(U_TD_BOOT),     \
 KC_MPRV,           KC_VOLD,           KC_VOLU,           KC_MNXT,           U_NU,              U_NA,              KC_LSFT,           KC_LCTL,           KC_LALT,           KC_LGUI,           \
 U_NU,              U_NU,              U_NU,              U_NU,              OU_AUTO,           U_NA,              TD(U_TD_U_MEDIA),  TD(U_TD_U_FUN),    KC_ALGR,           U_NA,              \
 U_NP,              U_NP,              KC_MUTE,           KC_MPLY,           KC_MSTP,           U_NA,              U_NA,              U_NA,              U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MEDIA_INVERTEDT \
-TD(U_TD_BOOT),     TD(U_TD_U_TAP),    TD(U_TD_U_EXTRA),  TD(U_TD_U_BASE),   U_NA,              RGB_TOG,           RGB_MOD,           KC_VOLU,           RGB_HUI,           RGB_SAI,           \
-KC_LGUI,           KC_LALT,           KC_LCTL,           KC_LSFT,           U_NA,              U_NU,              KC_MPRV,           KC_VOLD,           KC_MNXT,           RGB_VAI,           \
+TD(U_TD_BOOT),     TD(U_TD_U_TAP),    TD(U_TD_U_EXTRA),  TD(U_TD_U_BASE),   U_NA,              UG_TOGG,           UG_NEXT,           KC_VOLU,           UG_HUEU,           UG_SATU,           \
+KC_LGUI,           KC_LALT,           KC_LCTL,           KC_LSFT,           U_NA,              U_NU,              KC_MPRV,           KC_VOLD,           KC_MNXT,           UG_VALU,           \
 U_NA,              KC_ALGR,           TD(U_TD_U_FUN),    TD(U_TD_U_MEDIA),  U_NA,              OU_AUTO,           U_NU,              U_NU,              U_NU,              U_NU,              \
 U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              KC_MSTP,           KC_MPLY,           KC_MUTE,           U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MEDIA_VI \
-TD(U_TD_BOOT),     TD(U_TD_U_TAP),    TD(U_TD_U_EXTRA),  TD(U_TD_U_BASE),   U_NA,              RGB_MOD,           RGB_HUI,           RGB_SAI,           RGB_VAI,           RGB_TOG,           \
+TD(U_TD_BOOT),     TD(U_TD_U_TAP),    TD(U_TD_U_EXTRA),  TD(U_TD_U_BASE),   U_NA,              UG_NEXT,           UG_HUEU,           UG_SATU,           UG_VALU,           UG_TOGG,           \
 KC_LGUI,           KC_LALT,           KC_LCTL,           KC_LSFT,           U_NA,              KC_MPRV,           KC_VOLD,           KC_VOLU,           KC_MNXT,           U_NU,              \
 U_NA,              KC_ALGR,           TD(U_TD_U_FUN),    TD(U_TD_U_MEDIA),  U_NA,              U_NU,              U_NU,              U_NU,              U_NU,              OU_AUTO,           \
 U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              KC_MSTP,           KC_MPLY,           KC_MUTE,           U_NP,              U_NP
 
 #define MIRYOKU_ALTERNATIVES_MEDIA \
-TD(U_TD_BOOT),     TD(U_TD_U_TAP),    TD(U_TD_U_EXTRA),  TD(U_TD_U_BASE),   U_NA,              RGB_TOG,           RGB_MOD,           RGB_HUI,           RGB_SAI,           RGB_VAI,           \
+TD(U_TD_BOOT),     TD(U_TD_U_TAP),    TD(U_TD_U_EXTRA),  TD(U_TD_U_BASE),   U_NA,              UG_TOGG,           UG_NEXT,           UG_HUEU,           UG_SATU,           UG_VALU,           \
 KC_LGUI,           KC_LALT,           KC_LCTL,           KC_LSFT,           U_NA,              U_NU,              KC_MPRV,           KC_VOLD,           KC_VOLU,           KC_MNXT,           \
 U_NA,              KC_ALGR,           TD(U_TD_U_FUN),    TD(U_TD_U_MEDIA),  U_NA,              OU_AUTO,           U_NU,              U_NU,              U_NU,              U_NU,              \
 U_NP,              U_NP,              U_NA,              U_NA,              U_NA,              KC_MSTP,           KC_MPLY,           KC_MUTE,           U_NP,              U_NP
@@ -386,4 +386,4 @@ U_NP,              U_NP,              KC_APP,            KC_SPC,            KC_T
 U_UND,             U_CUT,             U_CPY,             U_PST,             U_RDO,             U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
 KC_LGUI,           KC_LALT,           KC_LCTL,           KC_LSFT,           U_NU,              U_NU,              KC_LSFT,           KC_LCTL,           KC_LALT,           KC_LGUI,           \
 U_UND,             U_CUT,             U_CPY,             U_PST,             U_RDO,             U_RDO,             U_PST,             U_CPY,             U_CUT,             U_UND,             \
-U_NP,              U_NP,              KC_BTN3,           KC_BTN1,           KC_BTN2,           KC_BTN2,           KC_BTN1,           KC_BTN3,           U_NP,              U_NP
+U_NP,              U_NP,              MS_BTN3,           MS_BTN1,           MS_BTN2,           MS_BTN2,           MS_BTN1,           MS_BTN3,           U_NP,              U_NP


### PR DESCRIPTION
QMK first deprecated and now removed the previous RGB and Mouse keycodes, see [QMK changelog 2025.08.31](https://docs.qmk.fm/ChangeLog/20250831)

This is an updated readme.org file to apply these changes. Tested with the latest QMK tag, 0.30.3. I also added the generated file in a different commit if needed.

- [mouse keycodes](https://docs.qmk.fm/features/mouse_keys#mapping-mouse-actions)
- [RGB matrix keycodes](https://docs.qmk.fm/features/rgb_matrix#keycodes)
- [RGB light keycodes](https://docs.qmk.fm/features/rgblight#keycodes)
